### PR TITLE
Add Supabase Table Schema for Patient, Therapist, Therapy Goal, Session and Packages (issue #20)

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,96 @@
+-- Create the patient table 
+CREATE TABLE patient (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    patient_name TEXT NOT NULL,
+    age INT2,
+    is_adult BOOLEAN NOT NULL,
+    guardian_name TEXT,
+    phone TEXT NOT NULL,
+    email TEXT NOT NULL,
+    guardian_relation TEXT,
+    autism_level INT2,
+    onboarded_on TIMESTAMPTZ,
+    therapist_id UUID,
+    gender TEXT,
+    country TEXT
+);
+
+-- Create the therapist table
+CREATE TABLE therapist (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    name TEXT NOT NULL,
+    email TEXT NOT NULL,
+    phone TEXT NOT NULL,
+    clinic_id UUID,
+    license TEXT,
+    approved BOOLEAN DEFAULT FALSE,
+    specialisation TEXT,
+    gender TEXT,
+    offered_therapies TEXT[],
+    age INT2,
+    regulatory_body TEXT
+);
+
+-- Create the package table
+CREATE TABLE package (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    name TEXT NOT NULL,
+    duration INT4 NOT NULL
+);
+
+-- Create the session table
+CREATE TABLE session (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    timestamp TIMESTAMPTZ NOT NULL,
+    therapist_id UUID,
+    patient_id UUID,
+    mode INT2,
+    duration INT4,
+    name TEXT
+);
+
+-- Create the therapy_goal table
+CREATE TABLE therapy_goal (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    performed_on TIMESTAMPTZ,
+    therapist_id UUID,
+    therapy_mode INT2,
+    duration INT4,
+    therapy_type INT2,
+    goals JSONB,
+    observations JSONB,
+    regressions JSONB,
+    activities JSONB,
+    patient_id UUID,
+    therapy_date INT8
+);
+
+-- Add foreign key constraints
+ALTER TABLE patient
+ADD CONSTRAINT fk_therapist
+FOREIGN KEY (therapist_id) REFERENCES therapist(id);
+
+ALTER TABLE session
+ADD CONSTRAINT fk_therapist
+FOREIGN KEY (therapist_id) REFERENCES therapist(id),
+ADD CONSTRAINT fk_patient
+FOREIGN KEY (patient_id) REFERENCES patient(id);
+
+ALTER TABLE therapy_goal
+ADD CONSTRAINT fk_therapist
+FOREIGN KEY (therapist_id) REFERENCES therapist(id),
+ADD CONSTRAINT fk_patient
+FOREIGN KEY (patient_id) REFERENCES patient(id);
+
+
+-- indexes on foreign keys for better performance
+CREATE INDEX idx_patient_therapist_id ON patient(therapist_id);
+CREATE INDEX idx_session_therapist_id ON session(therapist_id);
+CREATE INDEX idx_session_patient_id ON session(patient_id);
+CREATE INDEX idx_therapy_goal_therapist_id ON therapy_goal(therapist_id);
+CREATE INDEX idx_therapy_goal_patient_id ON therapy_goal(patient_id);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE patient (
     guardian_relation TEXT,
     autism_level INT2,
     onboarded_on TIMESTAMPTZ,
-    therapist_id UUID REFERENCES auth.users(id),
+    therapist_id UUID REFERENCES therapist(id),
     gender TEXT,
     country TEXT
 );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,6 +1,6 @@
--- Create the patient table 
+-- Create the patient table
 CREATE TABLE patient (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id UUID PRIMARY KEY REFERENCES auth.users(id),
     created_at TIMESTAMPTZ DEFAULT NOW(),
     patient_name TEXT NOT NULL,
     age INT2,
@@ -11,14 +11,14 @@ CREATE TABLE patient (
     guardian_relation TEXT,
     autism_level INT2,
     onboarded_on TIMESTAMPTZ,
-    therapist_id UUID,
+    therapist_id UUID REFERENCES auth.users(id),
     gender TEXT,
     country TEXT
 );
 
 -- Create the therapist table
 CREATE TABLE therapist (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id UUID PRIMARY KEY REFERENCES auth.users(id),
     created_at TIMESTAMPTZ DEFAULT NOW(),
     name TEXT NOT NULL,
     email TEXT NOT NULL,
@@ -46,8 +46,8 @@ CREATE TABLE session (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     created_at TIMESTAMPTZ DEFAULT NOW(),
     timestamp TIMESTAMPTZ NOT NULL,
-    therapist_id UUID,
-    patient_id UUID,
+    therapist_id UUID REFERENCES therapist(id), -- Fixed to reference therapist.id
+    patient_id UUID REFERENCES patient(id),     -- Fixed to reference patient.id
     mode INT2,
     duration INT4,
     name TEXT
@@ -58,7 +58,7 @@ CREATE TABLE therapy_goal (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     created_at TIMESTAMPTZ DEFAULT NOW(),
     performed_on TIMESTAMPTZ,
-    therapist_id UUID,
+    therapist_id UUID REFERENCES therapist(id), -- Fixed to reference therapist.id
     therapy_mode INT2,
     duration INT4,
     therapy_type INT2,
@@ -66,29 +66,11 @@ CREATE TABLE therapy_goal (
     observations JSONB,
     regressions JSONB,
     activities JSONB,
-    patient_id UUID,
+    patient_id UUID REFERENCES patient(id),     -- Fixed to reference patient.id
     therapy_date INT8
 );
 
--- Add foreign key constraints
-ALTER TABLE patient
-ADD CONSTRAINT fk_therapist
-FOREIGN KEY (therapist_id) REFERENCES therapist(id);
-
-ALTER TABLE session
-ADD CONSTRAINT fk_therapist
-FOREIGN KEY (therapist_id) REFERENCES therapist(id),
-ADD CONSTRAINT fk_patient
-FOREIGN KEY (patient_id) REFERENCES patient(id);
-
-ALTER TABLE therapy_goal
-ADD CONSTRAINT fk_therapist
-FOREIGN KEY (therapist_id) REFERENCES therapist(id),
-ADD CONSTRAINT fk_patient
-FOREIGN KEY (patient_id) REFERENCES patient(id);
-
-
--- indexes on foreign keys for better performance
+-- Indexes on foreign keys for better performance
 CREATE INDEX idx_patient_therapist_id ON patient(therapist_id);
 CREATE INDEX idx_session_therapist_id ON session(therapist_id);
 CREATE INDEX idx_session_patient_id ON session(patient_id);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #20

## 📝 Description

This pull request replicates the table schema in Supabase as per issue #20. It includes the creation of tables for `patient`, `therapist`, `package`, `session`, and `therapy_goal` with their respective fields and relationships. The schema has been updated based on the Figma design , ensuring all required fields are included.

## 🔧 Changes Made

- Renamed the `users` table to `patient` as per the requirements.
- Added fields to the `therapist` table: `license` (text), `approved` (bool), `specialisation` (text), `gender` (text), `offered_therapies` (text[]), `age` (int2), and `regulatory_body` (text).
- Updated the `patient` table with fields from the Figma design: `gender` (text) and `country` (text), while retaining original fields like `patient_name`, `age`, `guardian_name`, etc.
- Created a `supabase` directory and added the `schema.sql` file to define all tables and relationships.
- Established foreign key relationships between tables (e.g., `patient.therapist_id` references `therapist.id`).
- Created Indexes on foreign keys for better performance

## 📷 Screenshot

Attached below is the schema table view from Supabase, showing the created tables and their relationships:

![supabase-schema-fojnbpavofsxuypjxjvo](https://github.com/user-attachments/assets/9c7dc964-2e87-4ad1-b3ea-0cd9dbd24eac)


*Note*: I’ve downloaded the schema table view as a PNG and attached it here for reference.

Let me know if any further changes are needed.

## 🤝 Collaboration

Collaborated with: `@mdmohsin7` (my mentor, who assigned this issue)
