### PR TITLE
Add status column to session table per maintainer request

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -50,7 +50,8 @@ CREATE TABLE session (
     patient_id UUID REFERENCES patient(id),     -- Fixed to reference patient.id
     mode INT2,
     duration INT4,
-    name TEXT
+    name TEXT,
+    status TEXT NOT NULL CHECK (status IN ('Accepted', 'Declined', 'Pending')) DEFAULT 'Pending'
 );
 
 -- Create the therapy_goal table

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -51,7 +51,7 @@ CREATE TABLE session (
     mode INT2,
     duration INT4,
     name TEXT,
-    status TEXT NOT NULL CHECK (status IN ('Accepted', 'Declined', 'Pending')) DEFAULT 'Pending'
+    status TEXT NOT NULL CHECK (status IN ('accepted', 'declined', 'pending')) DEFAULT 'pending'
 );
 
 -- Create the therapy_goal table


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #38 

## 📝 Description
This PR adds a `status` column to the `session` table in `schema.sql` as requested by the maintainer. The column includes a CHECK constraint for the values `Accepted`, `Declined`, and `Pending`, with a default value of `Pending`.

## 🔧 Changes Made
- Updated `schema.sql` to add the `status` column to the `session` table with the following definition:
  - `status TEXT NOT NULL CHECK (status IN ('Accepted', 'Declined', 'Pending')) DEFAULT 'Pending'`.
- No code changes are made yet, as the application logic to handle the `status` column will be implemented in a future PR (pending further requirements).


### ✅ Checklist
- [x] I have read the contributing guidelines.
- [x] Any dependent changes have been merged and published in downstream modules.

## Additional Notes
- The `status` column defaults to `Pending`. Further UI or provider updates to manage `Accepted` and `Declined` states will be addressed in a subsequent PR.
- Please review the schema change and let me know if additional constraints or indexes are needed.