### PR TITLE
build: update Gradle version to 8.5 for compatibility

### DIFF
--- a/patient/android/gradle/wrapper/gradle-wrapper.properties
+++ b/patient/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,6 +2,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #99 


## 📝 Description

This pull request updates the Gradle version to **8.5** in `gradle-wrapper.properties`.

The update was necessary because **Gradle 8.2.1 is not fully compatible with Java 21**, which led to build issues. Gradle 8.5 includes official support for Java 21, ensuring compatibility with the latest JDK and improving build stability.

## 🔧 Changes Made

 Updated Gradle version from 8.2.1 to 8.5 in `gradle-wrapper.properties`.


## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: `@username` (optional)


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.

