### PR TITLE
Feat: Added Therapy Goals Features on Patient App

### DIFF
--- a/patient/lib/core/entities/therapy_entities/therapy_entities.dart
+++ b/patient/lib/core/entities/therapy_entities/therapy_entities.dart
@@ -1,0 +1,4 @@
+export './therapy_entities.dart';
+export './therapy_type_entity.dart';
+export './therapy_entity.dart';
+export './therapy_goal_entity.dart';

--- a/patient/lib/core/entities/therapy_entities/therapy_entity.dart
+++ b/patient/lib/core/entities/therapy_entities/therapy_entity.dart
@@ -1,0 +1,19 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+
+part 'therapy_entity.mapper.dart';
+
+@MappableClass()
+class TherapyEntity with TherapyEntityMappable {
+
+  final String id;
+
+  final String name;
+
+  TherapyEntity({
+    required this.id,
+    required this.name,
+  });
+
+
+}

--- a/patient/lib/core/entities/therapy_entities/therapy_entity.mapper.dart
+++ b/patient/lib/core/entities/therapy_entities/therapy_entity.mapper.dart
@@ -1,0 +1,114 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'therapy_entity.dart';
+
+class TherapyEntityMapper extends ClassMapperBase<TherapyEntity> {
+  TherapyEntityMapper._();
+
+  static TherapyEntityMapper? _instance;
+  static TherapyEntityMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TherapyEntityMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TherapyEntity';
+
+  static String _$id(TherapyEntity v) => v.id;
+  static const Field<TherapyEntity, String> _f$id = Field('id', _$id);
+  static String _$name(TherapyEntity v) => v.name;
+  static const Field<TherapyEntity, String> _f$name = Field('name', _$name);
+
+  @override
+  final MappableFields<TherapyEntity> fields = const {
+    #id: _f$id,
+    #name: _f$name,
+  };
+
+  static TherapyEntity _instantiate(DecodingData data) {
+    return TherapyEntity(id: data.dec(_f$id), name: data.dec(_f$name));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TherapyEntity fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TherapyEntity>(map);
+  }
+
+  static TherapyEntity fromJson(String json) {
+    return ensureInitialized().decodeJson<TherapyEntity>(json);
+  }
+}
+
+mixin TherapyEntityMappable {
+  String toJson() {
+    return TherapyEntityMapper.ensureInitialized()
+        .encodeJson<TherapyEntity>(this as TherapyEntity);
+  }
+
+  Map<String, dynamic> toMap() {
+    return TherapyEntityMapper.ensureInitialized()
+        .encodeMap<TherapyEntity>(this as TherapyEntity);
+  }
+
+  TherapyEntityCopyWith<TherapyEntity, TherapyEntity, TherapyEntity>
+      get copyWith => _TherapyEntityCopyWithImpl<TherapyEntity, TherapyEntity>(
+          this as TherapyEntity, $identity, $identity);
+  @override
+  String toString() {
+    return TherapyEntityMapper.ensureInitialized()
+        .stringifyValue(this as TherapyEntity);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TherapyEntityMapper.ensureInitialized()
+        .equalsValue(this as TherapyEntity, other);
+  }
+
+  @override
+  int get hashCode {
+    return TherapyEntityMapper.ensureInitialized()
+        .hashValue(this as TherapyEntity);
+  }
+}
+
+extension TherapyEntityValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TherapyEntity, $Out> {
+  TherapyEntityCopyWith<$R, TherapyEntity, $Out> get $asTherapyEntity =>
+      $base.as((v, t, t2) => _TherapyEntityCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class TherapyEntityCopyWith<$R, $In extends TherapyEntity, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({String? id, String? name});
+  TherapyEntityCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _TherapyEntityCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TherapyEntity, $Out>
+    implements TherapyEntityCopyWith<$R, TherapyEntity, $Out> {
+  _TherapyEntityCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TherapyEntity> $mapper =
+      TherapyEntityMapper.ensureInitialized();
+  @override
+  $R call({String? id, String? name}) => $apply(FieldCopyWithData(
+      {if (id != null) #id: id, if (name != null) #name: name}));
+  @override
+  TherapyEntity $make(CopyWithData data) => TherapyEntity(
+      id: data.get(#id, or: $value.id), name: data.get(#name, or: $value.name));
+
+  @override
+  TherapyEntityCopyWith<$R2, TherapyEntity, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _TherapyEntityCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}

--- a/patient/lib/core/entities/therapy_entities/therapy_goal_entity.dart
+++ b/patient/lib/core/entities/therapy_entities/therapy_goal_entity.dart
@@ -1,0 +1,44 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+import '../../../model/therapy_models/therapy_model.dart';
+
+part 'therapy_goal_entity.mapper.dart';
+
+@MappableClass()
+class TherapyGoalEntity with TherapyGoalEntityMappable {
+
+  @MappableField(key: 'performed_on')
+  final DateTime performedOn;
+
+  @MappableField(key: 'therapist_id')
+  final String? therapistId;
+
+  @MappableField(key: 'therapy_type_id')
+  final String therapyTypeId;
+
+  @MappableField(key: 'goals')
+  final List<TherapyModel> goals;
+
+  @MappableField(key: 'observations')
+  final List<TherapyModel> observations;
+
+  @MappableField(key: 'regressions')
+  final List<TherapyModel> regressions;
+
+  @MappableField(key: 'activities')
+  final List<TherapyModel> activities;
+
+  @MappableField(key: 'patient_id')
+  final String? patientId;
+
+  TherapyGoalEntity({
+    required this.performedOn,
+    this.therapistId,
+    required this.therapyTypeId,
+    required this.goals,
+    required this.observations,
+    required this.regressions,
+    required this.activities,
+    this.patientId,
+  });
+}

--- a/patient/lib/core/entities/therapy_entities/therapy_goal_entity.mapper.dart
+++ b/patient/lib/core/entities/therapy_entities/therapy_goal_entity.mapper.dart
@@ -1,0 +1,214 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'therapy_goal_entity.dart';
+
+class TherapyGoalEntityMapper extends ClassMapperBase<TherapyGoalEntity> {
+  TherapyGoalEntityMapper._();
+
+  static TherapyGoalEntityMapper? _instance;
+  static TherapyGoalEntityMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TherapyGoalEntityMapper._());
+      TherapyModelMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TherapyGoalEntity';
+
+  static DateTime _$performedOn(TherapyGoalEntity v) => v.performedOn;
+  static const Field<TherapyGoalEntity, DateTime> _f$performedOn =
+      Field('performedOn', _$performedOn, key: r'performed_on');
+  static String? _$therapistId(TherapyGoalEntity v) => v.therapistId;
+  static const Field<TherapyGoalEntity, String> _f$therapistId =
+      Field('therapistId', _$therapistId, key: r'therapist_id', opt: true);
+  static String _$therapyTypeId(TherapyGoalEntity v) => v.therapyTypeId;
+  static const Field<TherapyGoalEntity, String> _f$therapyTypeId =
+      Field('therapyTypeId', _$therapyTypeId, key: r'therapy_type_id');
+  static List<TherapyModel> _$goals(TherapyGoalEntity v) => v.goals;
+  static const Field<TherapyGoalEntity, List<TherapyModel>> _f$goals =
+      Field('goals', _$goals);
+  static List<TherapyModel> _$observations(TherapyGoalEntity v) =>
+      v.observations;
+  static const Field<TherapyGoalEntity, List<TherapyModel>> _f$observations =
+      Field('observations', _$observations);
+  static List<TherapyModel> _$regressions(TherapyGoalEntity v) => v.regressions;
+  static const Field<TherapyGoalEntity, List<TherapyModel>> _f$regressions =
+      Field('regressions', _$regressions);
+  static List<TherapyModel> _$activities(TherapyGoalEntity v) => v.activities;
+  static const Field<TherapyGoalEntity, List<TherapyModel>> _f$activities =
+      Field('activities', _$activities);
+  static String? _$patientId(TherapyGoalEntity v) => v.patientId;
+  static const Field<TherapyGoalEntity, String> _f$patientId =
+      Field('patientId', _$patientId, key: r'patient_id');
+
+  @override
+  final MappableFields<TherapyGoalEntity> fields = const {
+    #performedOn: _f$performedOn,
+    #therapistId: _f$therapistId,
+    #therapyTypeId: _f$therapyTypeId,
+    #goals: _f$goals,
+    #observations: _f$observations,
+    #regressions: _f$regressions,
+    #activities: _f$activities,
+    #patientId: _f$patientId,
+  };
+
+  static TherapyGoalEntity _instantiate(DecodingData data) {
+    return TherapyGoalEntity(
+        performedOn: data.dec(_f$performedOn),
+        therapistId: data.dec(_f$therapistId),
+        therapyTypeId: data.dec(_f$therapyTypeId),
+        goals: data.dec(_f$goals),
+        observations: data.dec(_f$observations),
+        regressions: data.dec(_f$regressions),
+        activities: data.dec(_f$activities),
+        patientId: data.dec(_f$patientId));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TherapyGoalEntity fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TherapyGoalEntity>(map);
+  }
+
+  static TherapyGoalEntity fromJson(String json) {
+    return ensureInitialized().decodeJson<TherapyGoalEntity>(json);
+  }
+}
+
+mixin TherapyGoalEntityMappable {
+  String toJson() {
+    return TherapyGoalEntityMapper.ensureInitialized()
+        .encodeJson<TherapyGoalEntity>(this as TherapyGoalEntity);
+  }
+
+  Map<String, dynamic> toMap() {
+    return TherapyGoalEntityMapper.ensureInitialized()
+        .encodeMap<TherapyGoalEntity>(this as TherapyGoalEntity);
+  }
+
+  TherapyGoalEntityCopyWith<TherapyGoalEntity, TherapyGoalEntity,
+          TherapyGoalEntity>
+      get copyWith =>
+          _TherapyGoalEntityCopyWithImpl<TherapyGoalEntity, TherapyGoalEntity>(
+              this as TherapyGoalEntity, $identity, $identity);
+  @override
+  String toString() {
+    return TherapyGoalEntityMapper.ensureInitialized()
+        .stringifyValue(this as TherapyGoalEntity);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TherapyGoalEntityMapper.ensureInitialized()
+        .equalsValue(this as TherapyGoalEntity, other);
+  }
+
+  @override
+  int get hashCode {
+    return TherapyGoalEntityMapper.ensureInitialized()
+        .hashValue(this as TherapyGoalEntity);
+  }
+}
+
+extension TherapyGoalEntityValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TherapyGoalEntity, $Out> {
+  TherapyGoalEntityCopyWith<$R, TherapyGoalEntity, $Out>
+      get $asTherapyGoalEntity => $base
+          .as((v, t, t2) => _TherapyGoalEntityCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class TherapyGoalEntityCopyWith<$R, $In extends TherapyGoalEntity,
+    $Out> implements ClassCopyWith<$R, $In, $Out> {
+  ListCopyWith<$R, TherapyModel,
+      TherapyModelCopyWith<$R, TherapyModel, TherapyModel>> get goals;
+  ListCopyWith<$R, TherapyModel,
+      TherapyModelCopyWith<$R, TherapyModel, TherapyModel>> get observations;
+  ListCopyWith<$R, TherapyModel,
+      TherapyModelCopyWith<$R, TherapyModel, TherapyModel>> get regressions;
+  ListCopyWith<$R, TherapyModel,
+      TherapyModelCopyWith<$R, TherapyModel, TherapyModel>> get activities;
+  $R call(
+      {DateTime? performedOn,
+      String? therapistId,
+      String? therapyTypeId,
+      List<TherapyModel>? goals,
+      List<TherapyModel>? observations,
+      List<TherapyModel>? regressions,
+      List<TherapyModel>? activities,
+      String? patientId});
+  TherapyGoalEntityCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+      Then<$Out2, $R2> t);
+}
+
+class _TherapyGoalEntityCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TherapyGoalEntity, $Out>
+    implements TherapyGoalEntityCopyWith<$R, TherapyGoalEntity, $Out> {
+  _TherapyGoalEntityCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TherapyGoalEntity> $mapper =
+      TherapyGoalEntityMapper.ensureInitialized();
+  @override
+  ListCopyWith<$R, TherapyModel,
+          TherapyModelCopyWith<$R, TherapyModel, TherapyModel>>
+      get goals => ListCopyWith(
+          $value.goals, (v, t) => v.copyWith.$chain(t), (v) => call(goals: v));
+  @override
+  ListCopyWith<$R, TherapyModel,
+          TherapyModelCopyWith<$R, TherapyModel, TherapyModel>>
+      get observations => ListCopyWith($value.observations,
+          (v, t) => v.copyWith.$chain(t), (v) => call(observations: v));
+  @override
+  ListCopyWith<$R, TherapyModel,
+          TherapyModelCopyWith<$R, TherapyModel, TherapyModel>>
+      get regressions => ListCopyWith($value.regressions,
+          (v, t) => v.copyWith.$chain(t), (v) => call(regressions: v));
+  @override
+  ListCopyWith<$R, TherapyModel,
+          TherapyModelCopyWith<$R, TherapyModel, TherapyModel>>
+      get activities => ListCopyWith($value.activities,
+          (v, t) => v.copyWith.$chain(t), (v) => call(activities: v));
+  @override
+  $R call(
+          {DateTime? performedOn,
+          Object? therapistId = $none,
+          String? therapyTypeId,
+          List<TherapyModel>? goals,
+          List<TherapyModel>? observations,
+          List<TherapyModel>? regressions,
+          List<TherapyModel>? activities,
+          Object? patientId = $none}) =>
+      $apply(FieldCopyWithData({
+        if (performedOn != null) #performedOn: performedOn,
+        if (therapistId != $none) #therapistId: therapistId,
+        if (therapyTypeId != null) #therapyTypeId: therapyTypeId,
+        if (goals != null) #goals: goals,
+        if (observations != null) #observations: observations,
+        if (regressions != null) #regressions: regressions,
+        if (activities != null) #activities: activities,
+        if (patientId != $none) #patientId: patientId
+      }));
+  @override
+  TherapyGoalEntity $make(CopyWithData data) => TherapyGoalEntity(
+      performedOn: data.get(#performedOn, or: $value.performedOn),
+      therapistId: data.get(#therapistId, or: $value.therapistId),
+      therapyTypeId: data.get(#therapyTypeId, or: $value.therapyTypeId),
+      goals: data.get(#goals, or: $value.goals),
+      observations: data.get(#observations, or: $value.observations),
+      regressions: data.get(#regressions, or: $value.regressions),
+      activities: data.get(#activities, or: $value.activities),
+      patientId: data.get(#patientId, or: $value.patientId));
+
+  @override
+  TherapyGoalEntityCopyWith<$R2, TherapyGoalEntity, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _TherapyGoalEntityCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}

--- a/patient/lib/core/entities/therapy_entities/therapy_type_entity.dart
+++ b/patient/lib/core/entities/therapy_entities/therapy_type_entity.dart
@@ -1,0 +1,28 @@
+
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'therapy_type_entity.mapper.dart';
+
+@MappableClass()
+class TherapyTypeEntity with TherapyTypeEntityMappable {
+
+  @MappableField(key: 'id')
+  final String therapyId;
+
+  @MappableField(key: 'created_at')
+  final DateTime createdAt;
+
+  @MappableField(key: 'name')
+  final String name;
+
+  @MappableField(key: 'description')
+  final String description;
+
+  TherapyTypeEntity({
+    required this.therapyId,
+    required this.createdAt,
+    required this.name,
+    required this.description,
+  });
+
+} 

--- a/patient/lib/core/entities/therapy_entities/therapy_type_entity.mapper.dart
+++ b/patient/lib/core/entities/therapy_entities/therapy_type_entity.mapper.dart
@@ -1,0 +1,147 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'therapy_type_entity.dart';
+
+class TherapyTypeEntityMapper extends ClassMapperBase<TherapyTypeEntity> {
+  TherapyTypeEntityMapper._();
+
+  static TherapyTypeEntityMapper? _instance;
+  static TherapyTypeEntityMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TherapyTypeEntityMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TherapyTypeEntity';
+
+  static String _$therapyId(TherapyTypeEntity v) => v.therapyId;
+  static const Field<TherapyTypeEntity, String> _f$therapyId =
+      Field('therapyId', _$therapyId, key: r'id');
+  static DateTime _$createdAt(TherapyTypeEntity v) => v.createdAt;
+  static const Field<TherapyTypeEntity, DateTime> _f$createdAt =
+      Field('createdAt', _$createdAt, key: r'created_at');
+  static String _$name(TherapyTypeEntity v) => v.name;
+  static const Field<TherapyTypeEntity, String> _f$name = Field('name', _$name);
+  static String _$description(TherapyTypeEntity v) => v.description;
+  static const Field<TherapyTypeEntity, String> _f$description =
+      Field('description', _$description);
+
+  @override
+  final MappableFields<TherapyTypeEntity> fields = const {
+    #therapyId: _f$therapyId,
+    #createdAt: _f$createdAt,
+    #name: _f$name,
+    #description: _f$description,
+  };
+
+  static TherapyTypeEntity _instantiate(DecodingData data) {
+    return TherapyTypeEntity(
+        therapyId: data.dec(_f$therapyId),
+        createdAt: data.dec(_f$createdAt),
+        name: data.dec(_f$name),
+        description: data.dec(_f$description));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TherapyTypeEntity fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TherapyTypeEntity>(map);
+  }
+
+  static TherapyTypeEntity fromJson(String json) {
+    return ensureInitialized().decodeJson<TherapyTypeEntity>(json);
+  }
+}
+
+mixin TherapyTypeEntityMappable {
+  String toJson() {
+    return TherapyTypeEntityMapper.ensureInitialized()
+        .encodeJson<TherapyTypeEntity>(this as TherapyTypeEntity);
+  }
+
+  Map<String, dynamic> toMap() {
+    return TherapyTypeEntityMapper.ensureInitialized()
+        .encodeMap<TherapyTypeEntity>(this as TherapyTypeEntity);
+  }
+
+  TherapyTypeEntityCopyWith<TherapyTypeEntity, TherapyTypeEntity,
+          TherapyTypeEntity>
+      get copyWith =>
+          _TherapyTypeEntityCopyWithImpl<TherapyTypeEntity, TherapyTypeEntity>(
+              this as TherapyTypeEntity, $identity, $identity);
+  @override
+  String toString() {
+    return TherapyTypeEntityMapper.ensureInitialized()
+        .stringifyValue(this as TherapyTypeEntity);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TherapyTypeEntityMapper.ensureInitialized()
+        .equalsValue(this as TherapyTypeEntity, other);
+  }
+
+  @override
+  int get hashCode {
+    return TherapyTypeEntityMapper.ensureInitialized()
+        .hashValue(this as TherapyTypeEntity);
+  }
+}
+
+extension TherapyTypeEntityValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TherapyTypeEntity, $Out> {
+  TherapyTypeEntityCopyWith<$R, TherapyTypeEntity, $Out>
+      get $asTherapyTypeEntity => $base
+          .as((v, t, t2) => _TherapyTypeEntityCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class TherapyTypeEntityCopyWith<$R, $In extends TherapyTypeEntity,
+    $Out> implements ClassCopyWith<$R, $In, $Out> {
+  $R call(
+      {String? therapyId,
+      DateTime? createdAt,
+      String? name,
+      String? description});
+  TherapyTypeEntityCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+      Then<$Out2, $R2> t);
+}
+
+class _TherapyTypeEntityCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TherapyTypeEntity, $Out>
+    implements TherapyTypeEntityCopyWith<$R, TherapyTypeEntity, $Out> {
+  _TherapyTypeEntityCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TherapyTypeEntity> $mapper =
+      TherapyTypeEntityMapper.ensureInitialized();
+  @override
+  $R call(
+          {String? therapyId,
+          DateTime? createdAt,
+          String? name,
+          String? description}) =>
+      $apply(FieldCopyWithData({
+        if (therapyId != null) #therapyId: therapyId,
+        if (createdAt != null) #createdAt: createdAt,
+        if (name != null) #name: name,
+        if (description != null) #description: description
+      }));
+  @override
+  TherapyTypeEntity $make(CopyWithData data) => TherapyTypeEntity(
+      therapyId: data.get(#therapyId, or: $value.therapyId),
+      createdAt: data.get(#createdAt, or: $value.createdAt),
+      name: data.get(#name, or: $value.name),
+      description: data.get(#description, or: $value.description));
+
+  @override
+  TherapyTypeEntityCopyWith<$R2, TherapyTypeEntity, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _TherapyTypeEntityCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}

--- a/patient/lib/core/repository/patient/patient_repository.dart
+++ b/patient/lib/core/repository/patient/patient_repository.dart
@@ -22,5 +22,9 @@ abstract interface class PatientRepository {
   ///   - If an error occurs while inserting the record, it is caught and returned as a failure.
   
   Future<ActionResult> scheduleAppointment(PatientScheduleAppointmentEntity appointmentEntity);
+
+  Future<ActionResult> getTherapyGoals({
+    required DateTime date,
+  });
  
 }

--- a/patient/lib/main.dart
+++ b/patient/lib/main.dart
@@ -10,12 +10,14 @@ import 'package:patient/provider/auth_provider.dart';
 import 'package:patient/repository/supabase_auth_repository.dart';
 
 import 'package:patient/provider/reports_provider.dart';
+import 'package:patient/repository/supabase_patient_repository.dart';
 
 import 'package:provider/provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 
 import 'provider/task_provider.dart';
+import 'provider/therapy_goals_provider.dart';
 
 
 Future<void> main() async {
@@ -48,7 +50,10 @@ Future<void> main() async {
         ),
         ChangeNotifierProvider(create: (_) => ReportsProvider()),
         ChangeNotifierProvider(create: (_) => TaskProvider()),
-        ChangeNotifierProvider(create: (_) => AppointmentsProvider())
+        ChangeNotifierProvider(create: (_) => AppointmentsProvider()),
+        ChangeNotifierProvider(create: (_) => TherapyGoalsProvider(
+          patientRepository: SupabasePatientRepository(supabaseClient: Supabase.instance.client),
+        ))
       ],
       child: const MyApp(),
     ),

--- a/patient/lib/model/therapy_models/therapy_goal_model.dart
+++ b/patient/lib/model/therapy_models/therapy_goal_model.dart
@@ -29,6 +29,26 @@ class TherapyGoalModel with TherapyGoalModelMappable {
   @MappableField(key: 'activities')
   final List<TherapyModel> activities;
 
+  @MappableField(key: 'duration')
+  final int? duration;
+
+  @MappableField(key: 'name')
+  final String? therapistName;
+
+  @MappableField(key: 'phone')
+  final String? therapistPhone;
+
+  @MappableField(key: 'email')
+  final String? therapistEmail;
+
+  @MappableField(key: 'therapy_type')
+  final String? therapyType;
+
+  @MappableField(key: 'therapy_mode')
+  final int? therapyMode;
+
+  @MappableField(key: 'specialization')
+  final String? specialization;
 
   TherapyGoalModel({
     required this.performedOn,
@@ -38,6 +58,13 @@ class TherapyGoalModel with TherapyGoalModelMappable {
     required this.observations,
     required this.regressions,
     required this.activities,
+    this.duration,
+    this.therapistName,
+    this.therapistPhone,
+    this.therapistEmail,
+    this.therapyType,
+    this.therapyMode,
+    this.specialization,
   });
 
 }

--- a/patient/lib/model/therapy_models/therapy_goal_model.dart
+++ b/patient/lib/model/therapy_models/therapy_goal_model.dart
@@ -1,0 +1,43 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+import 'therapy_model.dart';
+
+
+part 'therapy_goal_model.mapper.dart';
+
+@MappableClass()
+class TherapyGoalModel with TherapyGoalModelMappable {
+
+  @MappableField(key: 'performed_on')
+  final DateTime performedOn;
+
+  @MappableField(key: 'therapist_id')
+  final String? therapistId;
+
+  @MappableField(key: 'therapy_type_id')
+  final String therapyTypeId;
+
+  @MappableField(key: 'goals')
+  final List<TherapyModel> goals;
+
+  @MappableField(key: 'observations')
+  final List<TherapyModel> observations;
+
+  @MappableField(key: 'regressions')
+  final List<TherapyModel> regressions;
+
+  @MappableField(key: 'activities')
+  final List<TherapyModel> activities;
+
+
+  TherapyGoalModel({
+    required this.performedOn,
+    this.therapistId,
+    required this.therapyTypeId,
+    required this.goals,
+    required this.observations,
+    required this.regressions,
+    required this.activities,
+  });
+
+}

--- a/patient/lib/model/therapy_models/therapy_goal_model.mapper.dart
+++ b/patient/lib/model/therapy_models/therapy_goal_model.mapper.dart
@@ -43,6 +43,27 @@ class TherapyGoalModelMapper extends ClassMapperBase<TherapyGoalModel> {
   static List<TherapyModel> _$activities(TherapyGoalModel v) => v.activities;
   static const Field<TherapyGoalModel, List<TherapyModel>> _f$activities =
       Field('activities', _$activities);
+  static int? _$duration(TherapyGoalModel v) => v.duration;
+  static const Field<TherapyGoalModel, int> _f$duration =
+      Field('duration', _$duration, opt: true);
+  static String? _$therapistName(TherapyGoalModel v) => v.therapistName;
+  static const Field<TherapyGoalModel, String> _f$therapistName =
+      Field('therapistName', _$therapistName, key: r'name', opt: true);
+  static String? _$therapistPhone(TherapyGoalModel v) => v.therapistPhone;
+  static const Field<TherapyGoalModel, String> _f$therapistPhone =
+      Field('therapistPhone', _$therapistPhone, key: r'phone', opt: true);
+  static String? _$therapistEmail(TherapyGoalModel v) => v.therapistEmail;
+  static const Field<TherapyGoalModel, String> _f$therapistEmail =
+      Field('therapistEmail', _$therapistEmail, key: r'email', opt: true);
+  static String? _$therapyType(TherapyGoalModel v) => v.therapyType;
+  static const Field<TherapyGoalModel, String> _f$therapyType =
+      Field('therapyType', _$therapyType, key: r'therapy_type', opt: true);
+  static int? _$therapyMode(TherapyGoalModel v) => v.therapyMode;
+  static const Field<TherapyGoalModel, int> _f$therapyMode =
+      Field('therapyMode', _$therapyMode, key: r'therapy_mode', opt: true);
+  static String? _$specialization(TherapyGoalModel v) => v.specialization;
+  static const Field<TherapyGoalModel, String> _f$specialization =
+      Field('specialization', _$specialization, opt: true);
 
   @override
   final MappableFields<TherapyGoalModel> fields = const {
@@ -53,6 +74,13 @@ class TherapyGoalModelMapper extends ClassMapperBase<TherapyGoalModel> {
     #observations: _f$observations,
     #regressions: _f$regressions,
     #activities: _f$activities,
+    #duration: _f$duration,
+    #therapistName: _f$therapistName,
+    #therapistPhone: _f$therapistPhone,
+    #therapistEmail: _f$therapistEmail,
+    #therapyType: _f$therapyType,
+    #therapyMode: _f$therapyMode,
+    #specialization: _f$specialization,
   };
 
   static TherapyGoalModel _instantiate(DecodingData data) {
@@ -63,7 +91,14 @@ class TherapyGoalModelMapper extends ClassMapperBase<TherapyGoalModel> {
         goals: data.dec(_f$goals),
         observations: data.dec(_f$observations),
         regressions: data.dec(_f$regressions),
-        activities: data.dec(_f$activities));
+        activities: data.dec(_f$activities),
+        duration: data.dec(_f$duration),
+        therapistName: data.dec(_f$therapistName),
+        therapistPhone: data.dec(_f$therapistPhone),
+        therapistEmail: data.dec(_f$therapistEmail),
+        therapyType: data.dec(_f$therapyType),
+        therapyMode: data.dec(_f$therapyMode),
+        specialization: data.dec(_f$specialization));
   }
 
   @override
@@ -136,7 +171,14 @@ abstract class TherapyGoalModelCopyWith<$R, $In extends TherapyGoalModel, $Out>
       List<TherapyModel>? goals,
       List<TherapyModel>? observations,
       List<TherapyModel>? regressions,
-      List<TherapyModel>? activities});
+      List<TherapyModel>? activities,
+      int? duration,
+      String? therapistName,
+      String? therapistPhone,
+      String? therapistEmail,
+      String? therapyType,
+      int? therapyMode,
+      String? specialization});
   TherapyGoalModelCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
       Then<$Out2, $R2> t);
 }
@@ -177,7 +219,14 @@ class _TherapyGoalModelCopyWithImpl<$R, $Out>
           List<TherapyModel>? goals,
           List<TherapyModel>? observations,
           List<TherapyModel>? regressions,
-          List<TherapyModel>? activities}) =>
+          List<TherapyModel>? activities,
+          Object? duration = $none,
+          Object? therapistName = $none,
+          Object? therapistPhone = $none,
+          Object? therapistEmail = $none,
+          Object? therapyType = $none,
+          Object? therapyMode = $none,
+          Object? specialization = $none}) =>
       $apply(FieldCopyWithData({
         if (performedOn != null) #performedOn: performedOn,
         if (therapistId != $none) #therapistId: therapistId,
@@ -185,7 +234,14 @@ class _TherapyGoalModelCopyWithImpl<$R, $Out>
         if (goals != null) #goals: goals,
         if (observations != null) #observations: observations,
         if (regressions != null) #regressions: regressions,
-        if (activities != null) #activities: activities
+        if (activities != null) #activities: activities,
+        if (duration != $none) #duration: duration,
+        if (therapistName != $none) #therapistName: therapistName,
+        if (therapistPhone != $none) #therapistPhone: therapistPhone,
+        if (therapistEmail != $none) #therapistEmail: therapistEmail,
+        if (therapyType != $none) #therapyType: therapyType,
+        if (therapyMode != $none) #therapyMode: therapyMode,
+        if (specialization != $none) #specialization: specialization
       }));
   @override
   TherapyGoalModel $make(CopyWithData data) => TherapyGoalModel(
@@ -195,7 +251,14 @@ class _TherapyGoalModelCopyWithImpl<$R, $Out>
       goals: data.get(#goals, or: $value.goals),
       observations: data.get(#observations, or: $value.observations),
       regressions: data.get(#regressions, or: $value.regressions),
-      activities: data.get(#activities, or: $value.activities));
+      activities: data.get(#activities, or: $value.activities),
+      duration: data.get(#duration, or: $value.duration),
+      therapistName: data.get(#therapistName, or: $value.therapistName),
+      therapistPhone: data.get(#therapistPhone, or: $value.therapistPhone),
+      therapistEmail: data.get(#therapistEmail, or: $value.therapistEmail),
+      therapyType: data.get(#therapyType, or: $value.therapyType),
+      therapyMode: data.get(#therapyMode, or: $value.therapyMode),
+      specialization: data.get(#specialization, or: $value.specialization));
 
   @override
   TherapyGoalModelCopyWith<$R2, TherapyGoalModel, $Out2> $chain<$R2, $Out2>(

--- a/patient/lib/model/therapy_models/therapy_goal_model.mapper.dart
+++ b/patient/lib/model/therapy_models/therapy_goal_model.mapper.dart
@@ -1,0 +1,204 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'therapy_goal_model.dart';
+
+class TherapyGoalModelMapper extends ClassMapperBase<TherapyGoalModel> {
+  TherapyGoalModelMapper._();
+
+  static TherapyGoalModelMapper? _instance;
+  static TherapyGoalModelMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TherapyGoalModelMapper._());
+      TherapyModelMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TherapyGoalModel';
+
+  static DateTime _$performedOn(TherapyGoalModel v) => v.performedOn;
+  static const Field<TherapyGoalModel, DateTime> _f$performedOn =
+      Field('performedOn', _$performedOn, key: r'performed_on');
+  static String? _$therapistId(TherapyGoalModel v) => v.therapistId;
+  static const Field<TherapyGoalModel, String> _f$therapistId =
+      Field('therapistId', _$therapistId, key: r'therapist_id', opt: true);
+  static String _$therapyTypeId(TherapyGoalModel v) => v.therapyTypeId;
+  static const Field<TherapyGoalModel, String> _f$therapyTypeId =
+      Field('therapyTypeId', _$therapyTypeId, key: r'therapy_type_id');
+  static List<TherapyModel> _$goals(TherapyGoalModel v) => v.goals;
+  static const Field<TherapyGoalModel, List<TherapyModel>> _f$goals =
+      Field('goals', _$goals);
+  static List<TherapyModel> _$observations(TherapyGoalModel v) =>
+      v.observations;
+  static const Field<TherapyGoalModel, List<TherapyModel>> _f$observations =
+      Field('observations', _$observations);
+  static List<TherapyModel> _$regressions(TherapyGoalModel v) => v.regressions;
+  static const Field<TherapyGoalModel, List<TherapyModel>> _f$regressions =
+      Field('regressions', _$regressions);
+  static List<TherapyModel> _$activities(TherapyGoalModel v) => v.activities;
+  static const Field<TherapyGoalModel, List<TherapyModel>> _f$activities =
+      Field('activities', _$activities);
+
+  @override
+  final MappableFields<TherapyGoalModel> fields = const {
+    #performedOn: _f$performedOn,
+    #therapistId: _f$therapistId,
+    #therapyTypeId: _f$therapyTypeId,
+    #goals: _f$goals,
+    #observations: _f$observations,
+    #regressions: _f$regressions,
+    #activities: _f$activities,
+  };
+
+  static TherapyGoalModel _instantiate(DecodingData data) {
+    return TherapyGoalModel(
+        performedOn: data.dec(_f$performedOn),
+        therapistId: data.dec(_f$therapistId),
+        therapyTypeId: data.dec(_f$therapyTypeId),
+        goals: data.dec(_f$goals),
+        observations: data.dec(_f$observations),
+        regressions: data.dec(_f$regressions),
+        activities: data.dec(_f$activities));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TherapyGoalModel fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TherapyGoalModel>(map);
+  }
+
+  static TherapyGoalModel fromJson(String json) {
+    return ensureInitialized().decodeJson<TherapyGoalModel>(json);
+  }
+}
+
+mixin TherapyGoalModelMappable {
+  String toJson() {
+    return TherapyGoalModelMapper.ensureInitialized()
+        .encodeJson<TherapyGoalModel>(this as TherapyGoalModel);
+  }
+
+  Map<String, dynamic> toMap() {
+    return TherapyGoalModelMapper.ensureInitialized()
+        .encodeMap<TherapyGoalModel>(this as TherapyGoalModel);
+  }
+
+  TherapyGoalModelCopyWith<TherapyGoalModel, TherapyGoalModel, TherapyGoalModel>
+      get copyWith =>
+          _TherapyGoalModelCopyWithImpl<TherapyGoalModel, TherapyGoalModel>(
+              this as TherapyGoalModel, $identity, $identity);
+  @override
+  String toString() {
+    return TherapyGoalModelMapper.ensureInitialized()
+        .stringifyValue(this as TherapyGoalModel);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TherapyGoalModelMapper.ensureInitialized()
+        .equalsValue(this as TherapyGoalModel, other);
+  }
+
+  @override
+  int get hashCode {
+    return TherapyGoalModelMapper.ensureInitialized()
+        .hashValue(this as TherapyGoalModel);
+  }
+}
+
+extension TherapyGoalModelValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TherapyGoalModel, $Out> {
+  TherapyGoalModelCopyWith<$R, TherapyGoalModel, $Out>
+      get $asTherapyGoalModel => $base
+          .as((v, t, t2) => _TherapyGoalModelCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class TherapyGoalModelCopyWith<$R, $In extends TherapyGoalModel, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  ListCopyWith<$R, TherapyModel,
+      TherapyModelCopyWith<$R, TherapyModel, TherapyModel>> get goals;
+  ListCopyWith<$R, TherapyModel,
+      TherapyModelCopyWith<$R, TherapyModel, TherapyModel>> get observations;
+  ListCopyWith<$R, TherapyModel,
+      TherapyModelCopyWith<$R, TherapyModel, TherapyModel>> get regressions;
+  ListCopyWith<$R, TherapyModel,
+      TherapyModelCopyWith<$R, TherapyModel, TherapyModel>> get activities;
+  $R call(
+      {DateTime? performedOn,
+      String? therapistId,
+      String? therapyTypeId,
+      List<TherapyModel>? goals,
+      List<TherapyModel>? observations,
+      List<TherapyModel>? regressions,
+      List<TherapyModel>? activities});
+  TherapyGoalModelCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+      Then<$Out2, $R2> t);
+}
+
+class _TherapyGoalModelCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TherapyGoalModel, $Out>
+    implements TherapyGoalModelCopyWith<$R, TherapyGoalModel, $Out> {
+  _TherapyGoalModelCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TherapyGoalModel> $mapper =
+      TherapyGoalModelMapper.ensureInitialized();
+  @override
+  ListCopyWith<$R, TherapyModel,
+          TherapyModelCopyWith<$R, TherapyModel, TherapyModel>>
+      get goals => ListCopyWith(
+          $value.goals, (v, t) => v.copyWith.$chain(t), (v) => call(goals: v));
+  @override
+  ListCopyWith<$R, TherapyModel,
+          TherapyModelCopyWith<$R, TherapyModel, TherapyModel>>
+      get observations => ListCopyWith($value.observations,
+          (v, t) => v.copyWith.$chain(t), (v) => call(observations: v));
+  @override
+  ListCopyWith<$R, TherapyModel,
+          TherapyModelCopyWith<$R, TherapyModel, TherapyModel>>
+      get regressions => ListCopyWith($value.regressions,
+          (v, t) => v.copyWith.$chain(t), (v) => call(regressions: v));
+  @override
+  ListCopyWith<$R, TherapyModel,
+          TherapyModelCopyWith<$R, TherapyModel, TherapyModel>>
+      get activities => ListCopyWith($value.activities,
+          (v, t) => v.copyWith.$chain(t), (v) => call(activities: v));
+  @override
+  $R call(
+          {DateTime? performedOn,
+          Object? therapistId = $none,
+          String? therapyTypeId,
+          List<TherapyModel>? goals,
+          List<TherapyModel>? observations,
+          List<TherapyModel>? regressions,
+          List<TherapyModel>? activities}) =>
+      $apply(FieldCopyWithData({
+        if (performedOn != null) #performedOn: performedOn,
+        if (therapistId != $none) #therapistId: therapistId,
+        if (therapyTypeId != null) #therapyTypeId: therapyTypeId,
+        if (goals != null) #goals: goals,
+        if (observations != null) #observations: observations,
+        if (regressions != null) #regressions: regressions,
+        if (activities != null) #activities: activities
+      }));
+  @override
+  TherapyGoalModel $make(CopyWithData data) => TherapyGoalModel(
+      performedOn: data.get(#performedOn, or: $value.performedOn),
+      therapistId: data.get(#therapistId, or: $value.therapistId),
+      therapyTypeId: data.get(#therapyTypeId, or: $value.therapyTypeId),
+      goals: data.get(#goals, or: $value.goals),
+      observations: data.get(#observations, or: $value.observations),
+      regressions: data.get(#regressions, or: $value.regressions),
+      activities: data.get(#activities, or: $value.activities));
+
+  @override
+  TherapyGoalModelCopyWith<$R2, TherapyGoalModel, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _TherapyGoalModelCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}

--- a/patient/lib/model/therapy_models/therapy_model.dart
+++ b/patient/lib/model/therapy_models/therapy_model.dart
@@ -1,0 +1,18 @@
+import 'package:dart_mappable/dart_mappable.dart';
+
+
+part 'therapy_model.mapper.dart';
+
+@MappableClass()
+class TherapyModel with TherapyModelMappable {
+
+  final String id;
+
+  final String name;
+
+  TherapyModel({
+    required this.id,
+    required this.name,
+  });
+
+}

--- a/patient/lib/model/therapy_models/therapy_model.mapper.dart
+++ b/patient/lib/model/therapy_models/therapy_model.mapper.dart
@@ -1,0 +1,114 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'therapy_model.dart';
+
+class TherapyModelMapper extends ClassMapperBase<TherapyModel> {
+  TherapyModelMapper._();
+
+  static TherapyModelMapper? _instance;
+  static TherapyModelMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TherapyModelMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TherapyModel';
+
+  static String _$id(TherapyModel v) => v.id;
+  static const Field<TherapyModel, String> _f$id = Field('id', _$id);
+  static String _$name(TherapyModel v) => v.name;
+  static const Field<TherapyModel, String> _f$name = Field('name', _$name);
+
+  @override
+  final MappableFields<TherapyModel> fields = const {
+    #id: _f$id,
+    #name: _f$name,
+  };
+
+  static TherapyModel _instantiate(DecodingData data) {
+    return TherapyModel(id: data.dec(_f$id), name: data.dec(_f$name));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TherapyModel fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TherapyModel>(map);
+  }
+
+  static TherapyModel fromJson(String json) {
+    return ensureInitialized().decodeJson<TherapyModel>(json);
+  }
+}
+
+mixin TherapyModelMappable {
+  String toJson() {
+    return TherapyModelMapper.ensureInitialized()
+        .encodeJson<TherapyModel>(this as TherapyModel);
+  }
+
+  Map<String, dynamic> toMap() {
+    return TherapyModelMapper.ensureInitialized()
+        .encodeMap<TherapyModel>(this as TherapyModel);
+  }
+
+  TherapyModelCopyWith<TherapyModel, TherapyModel, TherapyModel> get copyWith =>
+      _TherapyModelCopyWithImpl<TherapyModel, TherapyModel>(
+          this as TherapyModel, $identity, $identity);
+  @override
+  String toString() {
+    return TherapyModelMapper.ensureInitialized()
+        .stringifyValue(this as TherapyModel);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TherapyModelMapper.ensureInitialized()
+        .equalsValue(this as TherapyModel, other);
+  }
+
+  @override
+  int get hashCode {
+    return TherapyModelMapper.ensureInitialized()
+        .hashValue(this as TherapyModel);
+  }
+}
+
+extension TherapyModelValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TherapyModel, $Out> {
+  TherapyModelCopyWith<$R, TherapyModel, $Out> get $asTherapyModel =>
+      $base.as((v, t, t2) => _TherapyModelCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class TherapyModelCopyWith<$R, $In extends TherapyModel, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call({String? id, String? name});
+  TherapyModelCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(Then<$Out2, $R2> t);
+}
+
+class _TherapyModelCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TherapyModel, $Out>
+    implements TherapyModelCopyWith<$R, TherapyModel, $Out> {
+  _TherapyModelCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TherapyModel> $mapper =
+      TherapyModelMapper.ensureInitialized();
+  @override
+  $R call({String? id, String? name}) => $apply(FieldCopyWithData(
+      {if (id != null) #id: id, if (name != null) #name: name}));
+  @override
+  TherapyModel $make(CopyWithData data) => TherapyModel(
+      id: data.get(#id, or: $value.id), name: data.get(#name, or: $value.name));
+
+  @override
+  TherapyModelCopyWith<$R2, TherapyModel, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _TherapyModelCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}

--- a/patient/lib/model/therapy_models/therapy_models.dart
+++ b/patient/lib/model/therapy_models/therapy_models.dart
@@ -1,0 +1,4 @@
+export './therapy_models.dart';
+export './therapy_type_model.dart';
+export './therapy_model.dart';
+export './therapy_goal_model.dart';

--- a/patient/lib/model/therapy_models/therapy_type_model.dart
+++ b/patient/lib/model/therapy_models/therapy_type_model.dart
@@ -1,0 +1,28 @@
+
+import 'package:dart_mappable/dart_mappable.dart';
+
+part 'therapy_type_model.mapper.dart';
+
+@MappableClass()
+class TherapyTypeModel with TherapyTypeModelMappable {
+
+  @MappableField(key: 'id')
+  final String therapyId;
+
+  @MappableField(key: 'created_at')
+  final DateTime createdAt;
+
+  @MappableField(key: 'name')
+  final String name;
+
+  @MappableField(key: 'description')
+  final String description;
+
+  TherapyTypeModel({
+    required this.therapyId,
+    required this.createdAt,
+    required this.name,
+    required this.description,
+  });
+
+} 

--- a/patient/lib/model/therapy_models/therapy_type_model.mapper.dart
+++ b/patient/lib/model/therapy_models/therapy_type_model.mapper.dart
@@ -1,0 +1,145 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'therapy_type_model.dart';
+
+class TherapyTypeModelMapper extends ClassMapperBase<TherapyTypeModel> {
+  TherapyTypeModelMapper._();
+
+  static TherapyTypeModelMapper? _instance;
+  static TherapyTypeModelMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = TherapyTypeModelMapper._());
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'TherapyTypeModel';
+
+  static String _$therapyId(TherapyTypeModel v) => v.therapyId;
+  static const Field<TherapyTypeModel, String> _f$therapyId =
+      Field('therapyId', _$therapyId, key: r'id');
+  static DateTime _$createdAt(TherapyTypeModel v) => v.createdAt;
+  static const Field<TherapyTypeModel, DateTime> _f$createdAt =
+      Field('createdAt', _$createdAt, key: r'created_at');
+  static String _$name(TherapyTypeModel v) => v.name;
+  static const Field<TherapyTypeModel, String> _f$name = Field('name', _$name);
+  static String _$description(TherapyTypeModel v) => v.description;
+  static const Field<TherapyTypeModel, String> _f$description =
+      Field('description', _$description);
+
+  @override
+  final MappableFields<TherapyTypeModel> fields = const {
+    #therapyId: _f$therapyId,
+    #createdAt: _f$createdAt,
+    #name: _f$name,
+    #description: _f$description,
+  };
+
+  static TherapyTypeModel _instantiate(DecodingData data) {
+    return TherapyTypeModel(
+        therapyId: data.dec(_f$therapyId),
+        createdAt: data.dec(_f$createdAt),
+        name: data.dec(_f$name),
+        description: data.dec(_f$description));
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static TherapyTypeModel fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<TherapyTypeModel>(map);
+  }
+
+  static TherapyTypeModel fromJson(String json) {
+    return ensureInitialized().decodeJson<TherapyTypeModel>(json);
+  }
+}
+
+mixin TherapyTypeModelMappable {
+  String toJson() {
+    return TherapyTypeModelMapper.ensureInitialized()
+        .encodeJson<TherapyTypeModel>(this as TherapyTypeModel);
+  }
+
+  Map<String, dynamic> toMap() {
+    return TherapyTypeModelMapper.ensureInitialized()
+        .encodeMap<TherapyTypeModel>(this as TherapyTypeModel);
+  }
+
+  TherapyTypeModelCopyWith<TherapyTypeModel, TherapyTypeModel, TherapyTypeModel>
+      get copyWith => _TherapyTypeModelCopyWithImpl(
+          this as TherapyTypeModel, $identity, $identity);
+  @override
+  String toString() {
+    return TherapyTypeModelMapper.ensureInitialized()
+        .stringifyValue(this as TherapyTypeModel);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return TherapyTypeModelMapper.ensureInitialized()
+        .equalsValue(this as TherapyTypeModel, other);
+  }
+
+  @override
+  int get hashCode {
+    return TherapyTypeModelMapper.ensureInitialized()
+        .hashValue(this as TherapyTypeModel);
+  }
+}
+
+extension TherapyTypeModelValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, TherapyTypeModel, $Out> {
+  TherapyTypeModelCopyWith<$R, TherapyTypeModel, $Out>
+      get $asTherapyTypeModel =>
+          $base.as((v, t, t2) => _TherapyTypeModelCopyWithImpl(v, t, t2));
+}
+
+abstract class TherapyTypeModelCopyWith<$R, $In extends TherapyTypeModel, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  $R call(
+      {String? therapyId,
+      DateTime? createdAt,
+      String? name,
+      String? description});
+  TherapyTypeModelCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+      Then<$Out2, $R2> t);
+}
+
+class _TherapyTypeModelCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, TherapyTypeModel, $Out>
+    implements TherapyTypeModelCopyWith<$R, TherapyTypeModel, $Out> {
+  _TherapyTypeModelCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<TherapyTypeModel> $mapper =
+      TherapyTypeModelMapper.ensureInitialized();
+  @override
+  $R call(
+          {String? therapyId,
+          DateTime? createdAt,
+          String? name,
+          String? description}) =>
+      $apply(FieldCopyWithData({
+        if (therapyId != null) #therapyId: therapyId,
+        if (createdAt != null) #createdAt: createdAt,
+        if (name != null) #name: name,
+        if (description != null) #description: description
+      }));
+  @override
+  TherapyTypeModel $make(CopyWithData data) => TherapyTypeModel(
+      therapyId: data.get(#therapyId, or: $value.therapyId),
+      createdAt: data.get(#createdAt, or: $value.createdAt),
+      name: data.get(#name, or: $value.name),
+      description: data.get(#description, or: $value.description));
+
+  @override
+  TherapyTypeModelCopyWith<$R2, TherapyTypeModel, $Out2> $chain<$R2, $Out2>(
+          Then<$Out2, $R2> t) =>
+      _TherapyTypeModelCopyWithImpl($value, $cast, t);
+}

--- a/patient/lib/presentation/operations/therapy_goals.dart
+++ b/patient/lib/presentation/operations/therapy_goals.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:easy_date_timeline/easy_date_timeline.dart';
+import 'package:patient/provider/therapy_goals_provider.dart';
+import 'package:provider/provider.dart';
+import '../../core/core.dart';
 import '../../gen/assets.gen.dart';
+import '../../model/therapy_models/therapy_models.dart';
 
 class TherapyGoalsScreen extends StatefulWidget {
   const TherapyGoalsScreen({super.key});
@@ -17,11 +21,9 @@ class TherapyGoalsScreenState extends State<TherapyGoalsScreen> {
   @override
   void initState() {
     super.initState();
-    // Refactor this code to use existing provider `allAssessment` instead of fetching data again
-    // Future.microtask(() {
-    //   Provider.of<AssessmentProvider>(context, listen: false)
-    //       .fetchAssessmentBySelectedId();
-    // });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<TherapyGoalsProvider>().fetchTherapyGoals(selectedDate);
+    });
   }
 
   @override
@@ -42,8 +44,8 @@ class TherapyGoalsScreenState extends State<TherapyGoalsScreen> {
           children: [
             // Date Picker Bar
             EasyDateTimeLinePicker.itemBuilder(
-              firstDate: DateTime(2025, 3, 1),
-              lastDate: DateTime(2025, 4, 1),
+              firstDate: DateTime(2024, 1, 1),
+              lastDate: DateTime(2025, 12, 31),
               focusedDate: selectedDate,
               itemExtent: screenWidth * 0.2,
               itemBuilder:
@@ -79,6 +81,7 @@ class TherapyGoalsScreenState extends State<TherapyGoalsScreen> {
                 setState(() {
                   selectedDate = date;
                 });
+                context.read<TherapyGoalsProvider>().fetchTherapyGoals(selectedDate);
               },
             ),
 
@@ -158,8 +161,8 @@ class TherapyGoalsScreenState extends State<TherapyGoalsScreen> {
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
                   _buildTabButton("Goals", 0),
-                  _buildTabButton("Achievements", 1),
-                  _buildTabButton("Observations", 2),
+                  _buildTabButton("Observations", 1),
+                  _buildTabButton("Regression", 2),
                 ],
               ),
             ),
@@ -227,44 +230,51 @@ class TherapyGoalsScreenState extends State<TherapyGoalsScreen> {
   }
 
   Widget _buildContent(int index) {
-    // final assessmentProvider = Provider.of<AssessmentProvider>(context);
-    const assessment = null; //assessmentProvider.assessment;
+    final therapyGoal = context.watch<TherapyGoalsProvider>().therapyGoal;
 
-    if (assessment == null || !assessment.containsKey('questions')) {
-      return Center(
-        child: Text(
-          "No Data Available",
-          style: TextStyle(fontSize: 16, color: Colors.grey.shade600),
-        ),
-      );
-    }
+    return Consumer<TherapyGoalsProvider>(builder: (context, provider, child) {
+      if(provider.apiStatus == ApiStatus.initial) {
+        return const SizedBox.shrink();
+      }
 
-    List<String> goals = assessment['questions']
-        .map<String>((q) => q['question'] as String)
-        .toList();
+      if (provider.apiStatus == ApiStatus.loading) {
+        return const Center(child: CircularProgressIndicator());
+      }
 
-    List<String> achievements = assessment['questions']
-        .map<String>((q) => "Achieved: ${q['question']}")
-        .toList();
-
-    List<String> observations = assessment['questions']
-        .map<String>((q) => "Observed: ${q['question']}")
-        .toList();
-
-    List<String> data =
-        index == 0 ? goals : (index == 1 ? achievements : observations);
-
-    return ListView.builder(
-      itemCount: data.length,
-      itemBuilder: (context, i) {
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8.0),
-          child: Text(
-            "${i + 1}. ${data[i]}",
-            style: TextStyle(fontSize: 14, color: Colors.grey.shade800),
-          ),
+      if (provider.apiStatus == ApiStatus.failure) {
+        return const Center(
+          child: Text('No data available'),
         );
-      },
-    );
+      }
+
+      List<TherapyModel> therapyGoalModel;
+
+      if(index == 0) {
+        therapyGoalModel = provider.therapyGoal!.goals;
+      } else if (index == 1) {
+        therapyGoalModel = provider.therapyGoal!.observations;
+      } else {
+        therapyGoalModel = provider.therapyGoal!.regressions;
+      }
+
+      if(therapyGoal == null || therapyGoalModel.isEmpty) {
+        return const Center(
+          child: Text('No data available'),
+        );
+      }
+
+      return ListView.builder(
+        itemCount: therapyGoalModel.length,
+        itemBuilder: (context, i) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8.0),
+            child: Text(
+              "${i + 1}. ${therapyGoalModel[i].name}",
+              style: TextStyle(fontSize: 14, color: Colors.grey.shade800),
+            ),
+          );
+        },
+      );
+    });
   }
 }

--- a/patient/lib/presentation/operations/therapy_goals.dart
+++ b/patient/lib/presentation/operations/therapy_goals.dart
@@ -88,64 +88,82 @@ class TherapyGoalsScreenState extends State<TherapyGoalsScreen> {
             const SizedBox(height: 20),
 
             // Therapy Card
-            Container(
-              padding: const EdgeInsets.all(16),
-              width: double.infinity,
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(12),
-                border:
-                    Border.all(color: const Color.fromARGB(82, 158, 158, 158)),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      CircleAvatar(
-                        radius: 24,
-                        backgroundImage:
-                            Assets.placeholders.therapistImg.provider(),
-                      ),
-                      const SizedBox(width: 12),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            "Therapist Name",
-                            style: TextStyle(
-                                fontWeight: FontWeight.bold,
-                                fontSize: 16,
-                                color: Colors.black),
-                          ),
-                          Text(
-                            "Neurologist",
-                            style: TextStyle(
-                                color: Colors.grey.shade600, fontSize: 14),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      _buildInfoColumn("Therapy", "Therapy Name"),
-                      _buildInfoColumn("Done at", "05:30 PM"),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      _buildInfoColumn("Therapy Mode", "Offline"),
-                      _buildInfoColumn("Duration", "1 hour 20 mins"),
-                    ],
-                  ),
-                ],
-              ),
-            ),
+            
+            Consumer<TherapyGoalsProvider>(
+              builder: (context, provider, child) {
+                if(provider.apiStatus == ApiStatus.initial) {
+                  return const SizedBox.shrink();
+                }
+
+                if(provider.apiStatus == ApiStatus.loading) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                if(provider.apiStatus == ApiStatus.failure) {
+                  return const Center(
+                    child: Text('No data available'),
+                  );
+                }
+
+              return Container(
+                padding: const EdgeInsets.all(16),
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(12),
+                  border: Border.all(
+                      color: const Color.fromARGB(82, 158, 158, 158)),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        CircleAvatar(
+                          radius: 24,
+                          backgroundImage:
+                              Assets.placeholders.therapistImg.provider(),
+                        ),
+                        const SizedBox(width: 12),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              provider.therapyGoal!.therapistName ?? "Therapist Name",
+                              style: const TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 16,
+                                  color: Colors.black),
+                            ),
+                            Text(
+                              provider.therapyGoal!.specialization ?? "",
+                              style: TextStyle(
+                                  color: Colors.grey.shade600, fontSize: 14),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        _buildInfoColumn("Therapy", provider.therapyGoal!.therapyType ?? "Therapy Type"),
+                        _buildInfoColumn("Done at", provider.therapyGoal!.performedOn.toString().split(" ")[0]),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        _buildInfoColumn("Therapy Mode", provider.therapyGoal?.therapyMode == 1 ? "Online" : "Offline"),
+                        _buildInfoColumn("Duration", "${provider.therapyGoal!.duration} mins"),
+                      ],
+                    ),
+                  ],
+                ),
+              );
+            }),
 
             const SizedBox(height: 25),
 

--- a/patient/lib/provider/therapy_goals_provider.dart
+++ b/patient/lib/provider/therapy_goals_provider.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:patient/core/core.dart';
+import 'package:patient/core/repository/repository.dart';
+import 'package:patient/core/utils/utils.dart';
+
+import '../model/therapy_models/therapy_models.dart';
+
+class TherapyGoalsProvider extends ChangeNotifier {
+
+  TherapyGoalsProvider({
+    required PatientRepository patientRepository,
+  }): _patientRepository = patientRepository;
+
+  final PatientRepository _patientRepository;
+
+  TherapyGoalModel? _therapyGoal;
+  ApiStatus _apiStatus = ApiStatus.initial;
+
+  TherapyGoalModel? get therapyGoal => _therapyGoal;
+  ApiStatus get apiStatus => _apiStatus;
+
+  void fetchTherapyGoals(DateTime date) async {
+    _apiStatus = ApiStatus.loading;
+    notifyListeners();
+
+    final result = await _patientRepository.getTherapyGoals(date: date);
+
+    if (result is ActionResultSuccess) {
+      _therapyGoal = result.data as TherapyGoalModel;
+      _apiStatus = ApiStatus.success;
+      notifyListeners();
+    } else {
+      _therapyGoal = null;
+      _apiStatus = ApiStatus.failure;
+      notifyListeners();
+    }
+  }
+}

--- a/patient/lib/repository/supabase_patient_repository.dart
+++ b/patient/lib/repository/supabase_patient_repository.dart
@@ -3,6 +3,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../core/entities/entities.dart';
 import '../core/repository/repository.dart';
+import '../model/therapy_models/therapy_models.dart';
 
 class SupabasePatientRepository implements PatientRepository {
 
@@ -21,6 +22,44 @@ class SupabasePatientRepository implements PatientRepository {
         data: 'Appointment scheduled successfully',
         statusCode: 200
       );
+    } catch(e) {
+      return ActionResultFailure(
+        errorMessage: e.toString(),
+        statusCode: 500
+      );
+    }
+  }
+  
+  @override
+  Future<ActionResult> getTherapyGoals({required DateTime date}) async {
+    try {
+      final response = await _supabaseClient.from('therapy_goal')
+      .select('*')
+      .eq('patient_id', _supabaseClient.auth.currentUser!.id);
+
+      if (response.isEmpty) {
+        return ActionResultFailure(
+          errorMessage: 'No therapy goals found',
+          statusCode: 404
+        );
+      }
+
+      // Filter the results by date
+      final filteredResponse = response.where((goal) {
+        final goalDate = DateTime.parse(goal['performed_on']);
+        return goalDate.year == date.year && 
+               goalDate.month == date.month && 
+               goalDate.day == date.day;
+      }).toList();
+
+      if (filteredResponse.isEmpty) {
+        return ActionResultFailure(
+          errorMessage: 'No therapy goals found for the specified date',
+          statusCode: 404
+        );
+      }
+
+      return ActionResultSuccess(data: TherapyGoalModelMapper.fromMap(filteredResponse.first), statusCode: 200);
     } catch(e) {
       return ActionResultFailure(
         errorMessage: e.toString(),

--- a/patient/lib/repository/supabase_patient_repository.dart
+++ b/patient/lib/repository/supabase_patient_repository.dart
@@ -59,7 +59,25 @@ class SupabasePatientRepository implements PatientRepository {
         );
       }
 
-      return ActionResultSuccess(data: TherapyGoalModelMapper.fromMap(filteredResponse.first), statusCode: 200);
+      final therapist = await _supabaseClient.from('therapist')
+      .select('*')
+      .eq('id', filteredResponse.first['therapist_id']).maybeSingle();
+
+      final therapyType = await _supabaseClient.from('therapy_type')
+      .select('*')
+      .eq('id', filteredResponse.first['therapy_type_id']).maybeSingle();
+
+      final therapyGoal = TherapyGoalModelMapper.fromMap(filteredResponse.first);
+
+      return ActionResultSuccess(data: therapyGoal.copyWith(
+        therapistName: therapist?['name'],
+        therapistPhone: therapist?['phone'],
+        therapistEmail: therapist?['email'],
+        therapyType: therapyType?['name'],
+        therapyMode: filteredResponse.first['therapy_mode'],
+        specialization: therapist?['specialisation']
+      ), statusCode: 200);
+      
     } catch(e) {
       return ActionResultFailure(
         errorMessage: e.toString(),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #110 


## 📝 Description

Following PR adds feature to view therapy goals using the patient app as well as the therapist details that did the therapy session.

## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: `@username` (optional)


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced models and entities for therapy goals, types, and related data with full serialization and copy capabilities.
  - Added a provider for managing and fetching therapy goals, enabling reactive UI updates based on loading and error states.
  - Implemented API integration to fetch therapy goals by date, including therapist and therapy type details.
  - Enhanced the therapy goals screen to display dynamic, provider-driven content with improved error and loading handling.

- **Refactor**
  - Updated the therapy goals screen to use the new provider and dynamic data instead of static content.

- **Chores**
  - Consolidated exports for therapy-related models and entities for easier import management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->