### PR TITLE
Fix pr merge detection

### DIFF
--- a/scripts/assign.py
+++ b/scripts/assign.py
@@ -142,15 +142,20 @@ def main():
                     search_data = search_response.json()
                     print(f"Search API Response for issue #{assigned_issue['number']}: {search_data}")
 
-                    if search_data.get("total_count", 0) > 0:
-                        pr_number = search_data["items"][0]["number"]
-                        pr_merge_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/merge"
-                        merge_response = requests.get(pr_merge_url, headers=headers)
+               if search_data.get("total_count", 0) > 0:
+                    pr_number = search_data["items"][0]["number"]
+                    pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
+                    pr_response = requests.get(pr_url, headers=headers)
 
-                        if merge_response.status_code == 204:
-                            print(f"PR #{pr_number} is merged for issue #{assigned_issue['number']}.")
-                            continue
-                    
+                    if pr_response.status_code == 200:
+                        pr_data = pr_response.json()
+
+                        if pr_data.get("merged"):
+                            print(
+                                f"PR #{pr_number} is merged for issue #{assigned_issue['number']}."
+                            )
+                                    continue
+
                     print(f"Issue #{assigned_issue.get('number')} has no merged PR")
                     issues_without_prs.append(assigned_issue.get("number"))
 

--- a/scripts/assign.py
+++ b/scripts/assign.py
@@ -142,19 +142,19 @@ def main():
                     search_data = search_response.json()
                     print(f"Search API Response for issue #{assigned_issue['number']}: {search_data}")
 
-        if search_data.get("total_count", 0) > 0:
-            pr_number = search_data["items"][0]["number"]
-            pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
-            pr_response = requests.get(pr_url, headers=headers)
+                   if search_data.get("total_count", 0) > 0:
+                      pr_number = search_data["items"][0]["number"]
+                      pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
+                      pr_response = requests.get(pr_url, headers=headers)
 
-            if pr_response.status_code == 200:
-                pr_data = pr_response.json()
+                      if pr_response.status_code == 200:
+                         pr_data = pr_response.json()
 
-                if pr_data.get("merged"):
-                    print(
-                    f"PR #{pr_number} is merged for issue #{assigned_issue['number']}."
-                    )
-                    continue
+                         if pr_data.get("merged"):
+                            print(
+                            f"PR #{pr_number} is merged for issue #{assigned_issue['number']}."
+                            )
+                            continue
 
                     print(f"Issue #{assigned_issue.get('number')} has no merged PR")
                     issues_without_prs.append(assigned_issue.get("number"))

--- a/scripts/assign.py
+++ b/scripts/assign.py
@@ -142,19 +142,19 @@ def main():
                     search_data = search_response.json()
                     print(f"Search API Response for issue #{assigned_issue['number']}: {search_data}")
 
-               if search_data.get("total_count", 0) > 0:
-                    pr_number = search_data["items"][0]["number"]
-                    pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
-                    pr_response = requests.get(pr_url, headers=headers)
+        if search_data.get("total_count", 0) > 0:
+            pr_number = search_data["items"][0]["number"]
+            pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
+            pr_response = requests.get(pr_url, headers=headers)
 
-                    if pr_response.status_code == 200:
-                        pr_data = pr_response.json()
+            if pr_response.status_code == 200:
+                pr_data = pr_response.json()
 
-                        if pr_data.get("merged"):
-                            print(
-                                f"PR #{pr_number} is merged for issue #{assigned_issue['number']}."
-                            )
-                                    continue
+                if pr_data.get("merged"):
+                    print(
+                    f"PR #{pr_number} is merged for issue #{assigned_issue['number']}."
+                    )
+                    continue
 
                     print(f"Issue #{assigned_issue.get('number')} has no merged PR")
                     issues_without_prs.append(assigned_issue.get("number"))


### PR DESCRIPTION
This PR fixes an issue in the assignment workflow where pull requests were incorrectly treated as merged.

Previously, the code used the GET /pulls/{pull_number}/merge endpoint and checked for a 204 status code. However, this endpoint only indicates whether a pull request is mergeable, not whether it has already been merged. As a result, unmerged PRs could be mistakenly considered completed.

This change updates the logic to:

Fetch pull request details using GET /pulls/{pull_number}

Reliably determine merge completion by checking the merged field in the response

This ensures that only actually merged pull requests are treated as completed when validating active issue assignments.
Fixes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal merge status validation logic with no direct impact to end-user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->