### PR TITLE
fix: declined/pending sessions no longer block booking slots

### DIFF
--- a/patient/lib/presentation/appointments/widgets/timeslot_bottom_sheet.dart
+++ b/patient/lib/presentation/appointments/widgets/timeslot_bottom_sheet.dart
@@ -19,6 +19,13 @@ class TimeSlotBottomSheet extends StatelessWidget {
     return Consumer<AppointmentsProvider>(
       builder: (context, appointmentsProvider, child) {
         // Ensure available slots are loaded
+        if (appointmentsProvider.isFetchingSlots) {
+          return const SizedBox(
+            height: 160,
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+
         if (appointmentsProvider.availableTimeSlots.isEmpty) {
           return Center(
               child: Text(

--- a/patient/lib/provider/appointments_provider.dart
+++ b/patient/lib/provider/appointments_provider.dart
@@ -23,6 +23,8 @@ class AppointmentsProvider extends ChangeNotifier {
 
   final List<AppointmentModel> _appointments = [];
   List<String> _availableTimeSlots = [];
+  bool _isFetchingSlots = false;
+  int _fetchToken = 0; 
 
   String _selectedService = 'Consultation';
   DateTime? _selectedDate;
@@ -36,6 +38,7 @@ class AppointmentsProvider extends ChangeNotifier {
   String get selectedTimeSlot => _selectedTimeSlot;
   bool get hasAppointments => _appointments.isNotEmpty;
   List<String> get availableTimeSlots => _availableTimeSlots;
+  bool get isFetchingSlots => _isFetchingSlots;
  // List<Map<String, dynamic>> get timeSlots => List.unmodifiable(_timeSlots);
 
 
@@ -68,9 +71,64 @@ class AppointmentsProvider extends ChangeNotifier {
   }
 
   void _availableBookingSlots(DateTime date) async {
+    final token = ++_fetchToken;
+    _isFetchingSlots = true;
+    _availableTimeSlots = [];
+    notifyListeners();
     try {
+      final supabase = Supabase.instance.client;
+      final currentUser = supabase.auth.currentUser;
+      if (currentUser == null) {
+        availableTimeSlots = [];
+        return;
+      }
+      final userId = currentUser.id;
+
+      final patientRow = await supabase
+          .from('patient')
+          .select('therapist_id')
+          .eq('id', userId)
+          .maybeSingle();
+
+      if (token != _fetchToken) return;
+
+      var therapistId = patientRow?['therapist_id'] as String?;
+
+      if (therapistId == null || therapistId.isEmpty) {
+        final sessionRow = await supabase
+            .from('session')
+            .select('therapist_id')
+            .eq('patient_id', userId)
+            .eq('status', 'accepted')
+            .order('timestamp', ascending: false)
+            .limit(1)
+            .maybeSingle();
+
+        if (token != _fetchToken) return;
+        therapistId = sessionRow?['therapist_id'] as String?;
+      }
+
+      if (therapistId == null || therapistId.isEmpty) {
+        availableTimeSlots = [];
+        return;
+      }
+
+      final therapistRow = await supabase
+          .from('therapist')
+          .select('start_availability_time, end_availability_time')
+          .eq('id', therapistId)
+          .maybeSingle();
+
+      if (token != _fetchToken) return;
+
+      final startTime = therapistRow?['start_availability_time'] as String? ?? '9:00';
+      final endTime = therapistRow?['end_availability_time'] as String? ?? '18:00';
+
       final result = await _authRepository.getAvailableBookingSlotsForTherapist(
-        '5929f9bb-e294-4812-ae08-4a1c10ca7123', date, '9:30', '18:00');
+        therapistId, date, startTime, endTime);
+
+      if (token != _fetchToken) return;
+
       if(result is ActionResultSuccess) {
         availableTimeSlots = result.data as List<String>;
       } else {
@@ -78,9 +136,14 @@ class AppointmentsProvider extends ChangeNotifier {
       }
     } catch(e) {
       print(e);
-      availableTimeSlots = [];
+      if (token == _fetchToken) {
+        availableTimeSlots = [];
+      }
     } finally {
-      notifyListeners();
+      if (token == _fetchToken) {
+        _isFetchingSlots = false;
+        notifyListeners();
+      }
     }
   }
 

--- a/patient/lib/repository/supabase_auth_repository.dart
+++ b/patient/lib/repository/supabase_auth_repository.dart
@@ -99,11 +99,12 @@ class SupabaseAuthRepository implements AuthRepository {
           .from('session')
           .select('timestamp')
           .eq('therapist_id', therapistId)
-          .gte('timestamp', startOfDay.toIso8601String())
-          .lte('timestamp', endOfDay.toIso8601String());
+          .eq('status', 'accepted')
+          .gte('timestamp', startOfDay.toUtc().toIso8601String())
+          .lte('timestamp', endOfDay.toUtc().toIso8601String());
 
       final bookedTimestamps =
-          (response as List).map((e) => DateTime.parse(e['timestamp'])).toSet();
+          (response as List).map((e) => DateTime.parse(e['timestamp']).toLocal()).toSet();
 
       final startHourOfTherapist =
           int.parse(startTimeOfTherapist.split(':')[0]);


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #162 


## 📝 Description

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->
Declined, cancelled, and pending sessions were incorrectly blocking booking
slots in the appointment scheduling flow. This PR fixes the root cause in
the repository layer and two additional bugs discovered during debugging
in the provider and UI layers.

## 🔧 Changes Made

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- patient/lib/repository/supabase_auth_repository.dart
  - Added .eq('status', 'accepted') filter so only confirmed sessions block
    time slots (core fix for #162)
  - Added .toUtc().toIso8601String() on startOfDay and endOfDay before
    sending to Supabase so the timestamp range query covers the correct
    local calendar day regardless of device timezone
  - Added .toLocal() when parsing timestamps returned from Supabase so
    the hour/minute comparison with local slot times is in the same timezone
- patient/lib/provider/appointments_provider.dart
  - Replaced hardcoded therapist UUID and hardcoded '9:30' start time with
    a live lookup: reads therapist_id from the patient table, falls back to
    the session table if not yet assigned, then fetches real
    start_availability_time and end_availability_time from the therapist table
  - Added _isFetchingSlots loading state to prevent a race condition where
    the time slot bottom sheet opened before the async Supabase fetch completed
- patient/lib/presentation/appointments/widgets/timeslot_bottom_sheet.dart
  - Added an isFetchingSlots check that shows a CircularProgressIndicator
    while slots are loading, preventing the premature "No Slots Available"
    message caused by the race condition above

## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->
Before: 9:00 AM slot was missing from the available slots list even though
the only session at that time had status = 'declined'.
After: 9:00 AM slot correctly appears as available when no accepted session
exists at that time.
<img width="379" height="834" alt="Screenshot 2026-02-27 at 11 09 33 AM" src="https://github.com/user-attachments/assets/d3759337-5f82-4906-a105-a9228b119c55" />

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with:  N/A


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visible loading indicator while appointment slots are being fetched to avoid showing "No Slots" prematurely.

* **Bug Fixes / Improvements**
  * More reliable slot retrieval with improved therapist lookup and request coalescing to prevent stale results.
  * Dynamic availability window handling instead of fixed times.
  * Session filtering limited to accepted sessions.
  * Timestamps now displayed in local time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->