### PR TITLE
fix: correct table name from 'patients' to 'patient' in getTherapistPatients

### DIFF
--- a/therapist/lib/repository/supabase_therapist_repository.dart
+++ b/therapist/lib/repository/supabase_therapist_repository.dart
@@ -67,7 +67,7 @@ class SupabaseTherapistRepository implements TherapistRepository {
   @override
   Future<ActionResult> getTherapistPatients() async {
    try {
-      final response = await _supabaseClient.from('patients')
+      final response = await _supabaseClient.from('patient')
       .select('*')
       .eq('therapist_id', _supabaseClient.auth.currentUser!.id);
     


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #165 


## 📝 Description

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->
`getTherapistPatients` was querying a non-existent table `patients` instead
of the correct table `patient` (singular), causing the function to always
fail with a Supabase `relation "patients" does not exist` error.

## 🔧 Changes Made

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- `therapist/lib/repository/supabase_therapist_repository.dart`: Changed
  `.from('patients')` → `.from('patient')` on line 70

## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->
N/A — one character typo fix, no visual changes.

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: N/A


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the database table reference for retrieving therapist patient records, ensuring data is fetched from the correct source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->