### PR TITLE
fix: prevent PGRST116 crash in getTodayActivities by adding limit(1) before maybeSingle

### DIFF
--- a/patient/lib/repository/supabase_patient_repository.dart
+++ b/patient/lib/repository/supabase_patient_repository.dart
@@ -146,8 +146,9 @@ class SupabasePatientRepository implements PatientRepository {
       .select('*')
       .eq('patient_id', _supabaseClient.auth.currentUser!.id)
       .gte('date', startDate.toIso8601String())
-      .lte('date', endDate.toIso8601String())
+      .lt('date', endDate.toIso8601String())
       .order('date', ascending: false)
+      .order('created_at', ascending: false)
       .limit(1)
       .maybeSingle();
       

--- a/patient/lib/repository/supabase_patient_repository.dart
+++ b/patient/lib/repository/supabase_patient_repository.dart
@@ -147,6 +147,8 @@ class SupabasePatientRepository implements PatientRepository {
       .eq('patient_id', _supabaseClient.auth.currentUser!.id)
       .gte('date', startDate.toIso8601String())
       .lte('date', endDate.toIso8601String())
+      .order('date', ascending: false)
+      .limit(1)
       .maybeSingle();
       
       if (response == null || response.isEmpty) {


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #167 


## 📝 Description

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->
`getTodayActivities` was calling `.maybeSingle()` directly after a date 
range filter on `daily_activity_logs`. If more than one log existed for 
the same patient on the same day, Supabase would throw a `PGRST116` error 
("Results contain more than one row"), causing the tasks page to silently 
show "No activities found".

## 🔧 Changes Made

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- `patient/lib/repository/supabase_patient_repository.dart`: Added 
  `.order('date', ascending: false)` and `.limit(1)` before `.maybeSingle()` 
  to ensure at most one row is returned, always picking the most recent log.
## 📷 Screenshots or Visual Changes (if applicable)
N/A — error only occurs when duplicate logs exist in the DB.
<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: N/A


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patient activity log retrieval to return only the most recent activity entry for the current day, ensuring consistent and accurate activity data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->