### PR TITLE
fix: add ownership check to deleteAppointment to prevent unauthorized session deletion

### DIFF
--- a/patient/lib/repository/supabase_patient_repository.dart
+++ b/patient/lib/repository/supabase_patient_repository.dart
@@ -123,7 +123,10 @@ class SupabasePatientRepository implements PatientRepository {
   @override
   Future<ActionResult> deleteAppointment(String id) async {
     try {
-      await _supabaseClient.from('session').delete().eq('id', id).eq('patient_id', _supabaseClient.auth.currentUser!.id);
+      final response = await _supabaseClient.from('session').delete().eq('id', id).eq('patient_id', _supabaseClient.auth.currentUser!.id).select();
+      if (response.isEmpty) {
+        return ActionResultFailure(errorMessage: 'Appointment not found or not authorized', statusCode: 404);
+      }
       return ActionResultSuccess(
         data: 'Appointment deleted successfully',
         statusCode: 200


### PR DESCRIPTION
… deletion (#169)

<!-- What issue does this PR close? -->
Closes #169 


## 📝 Description

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->
`deleteAppointment` was deleting sessions by `id` alone with no check 
that the session belonged to the authenticated patient. Any authenticated 
patient could delete any other patient's session by supplying its UUID.
RLS is also disabled on the `session` table, so there was no database-level 
safety net either.
## 🔧 Changes Made

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- `patient/lib/repository/supabase_patient_repository.dart`: Added 
  `.eq('patient_id', _supabaseClient.auth.currentUser!.id)` to the delete 
  query so only the session owner can delete their own sessions.
## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->
N/A — authorization fix, no visual changes.

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: N/A


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Appointment deletion now includes authorization validation
  * Improved error handling for deletion operations with proper status codes and messages for unauthorized or non-existent appointments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->