### PR TITLE
fix(therapist): Remove unused imports across therapist app

### DIFF
--- a/therapist/lib/core/repository/therapist/therapist_repository.dart
+++ b/therapist/lib/core/repository/therapist/therapist_repository.dart
@@ -1,5 +1,4 @@
 import 'package:therapist/core/result/action_result.dart';
-import 'package:therapist/core/models/profession_model.dart';
 
 abstract interface class TherapistRepository {
 

--- a/therapist/lib/presentation/auth/auth_screen.dart
+++ b/therapist/lib/presentation/auth/auth_screen.dart
@@ -3,9 +3,7 @@ import 'dart:async';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'package:therapist/presentation/auth/personal_details_screen.dart';
 import 'package:therapist/presentation/auth/widgets/google_signin_button.dart';
-import '../home/home_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:therapist/provider/auth_provider.dart';
 

--- a/therapist/lib/presentation/consultation/consultation_request_detail_screen.dart
+++ b/therapist/lib/presentation/consultation/consultation_request_detail_screen.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
-import 'package:therapist/core/entities/consultation/consultation_request_entity.dart';
 import 'package:therapist/model/consultation/consultation_request_model.dart';
-import 'package:therapist/provider/consultation_provider.dart';
 
 class ConsultationRequestDetailScreen extends StatefulWidget {
   final ConsultationRequestModel request;

--- a/therapist/lib/presentation/home/widgets/patient_card.dart
+++ b/therapist/lib/presentation/home/widgets/patient_card.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:therapist/presentation/therapy_goals/therapy_goals_screen.dart';
 import 'package:therapist/presentation/therapy_goals/therapy_home_screen.dart';
 
 class PatientCard extends StatelessWidget {

--- a/therapist/lib/presentation/therapy_goals/therapy_home_screen.dart
+++ b/therapist/lib/presentation/therapy_goals/therapy_home_screen.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:therapist/presentation/therapy_goals/therapy_goals_screen.dart';
 import 'package:therapist/presentation/therapy_goals/widgets/therapy_goal_home_screen_option_tile.dart';
-import 'package:therapist/repository/supabase_therapy_repository.dart';
 
-import '../../core/repository/therapy/therapy_repository.dart';
-import '../../provider/daily_activities_provider.dart';
 import '../daily_activities/daily_activities_screen.dart';
 
 class TherapyHomeScreen extends StatelessWidget {

--- a/therapist/lib/provider/consultation_provider.dart
+++ b/therapist/lib/provider/consultation_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:therapist/core/entities/consultation/consultation_request_entity.dart';
 import 'package:therapist/core/repository/consultation/consultation_repository.dart';
 import 'package:therapist/core/result/result.dart';
 import 'package:therapist/core/utils/api_status_enum.dart';

--- a/therapist/lib/provider/therapist_provider.dart
+++ b/therapist/lib/provider/therapist_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:therapist/core/entities/auth_entities/therapist_personal_info_entity.dart';
 import 'package:therapist/core/models/profession_model.dart';
 import 'package:therapist/core/repository/therapist/therapist_repository.dart';
 import 'package:therapist/core/result/result.dart';

--- a/therapist/lib/repository/supabase_therapy_repository.dart
+++ b/therapist/lib/repository/supabase_therapy_repository.dart
@@ -1,17 +1,11 @@
-import 'dart:convert';
-
-import 'package:flutter/foundation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:therapist/core/entities/therapy_entities/therapy_entities.dart';
-import 'package:therapist/core/entities/therapy_entities/therapy_type_entity.dart';
 import 'package:therapist/core/result/result.dart';
 import 'package:therapist/model/therapy_models/therapy_models.dart';
 import 'package:uuid/uuid.dart';
 
-import '../core/entities/daily_activity_entities/daily_activity_model.dart' show DailyActivityModel;
 import '../core/entities/daily_activity_entities/daily_activity_response.dart' show DailyActivityResponse, DailyActivityResponseMapper;
 import '../core/repository/repository.dart';
-import '../model/daily_activities/daily_activity_response_model.dart';
 
 class SupabaseTherapyRepository implements TherapyRepository {
   final _supabaseClient = Supabase.instance.client;


### PR DESCRIPTION
## Summary

Fixes #196

Removes 14 `unused_import` warnings and 1 `unnecessary_import` warning flagged by `flutter analyze` in the `therapist/` app.

## Changes

| File | Action |
|------|--------|
| `lib/core/repository/therapist/therapist_repository.dart` | Removed unused `profession_model.dart` import |
| `lib/presentation/auth/auth_screen.dart` | Removed unused `personal_details_screen.dart` and `home_screen.dart` imports |
| `lib/presentation/consultation/consultation_request_detail_screen.dart` | Removed unused `provider.dart`, `consultation_request_entity.dart`, and `consultation_provider.dart` imports (these were only referenced in commented-out code) |
| `lib/presentation/home/widgets/patient_card.dart` | Removed unused `therapy_goals_screen.dart` import |
| `lib/presentation/therapy_goals/therapy_home_screen.dart` | Removed unused `provider.dart`, `supabase_therapy_repository.dart`, `therapy_repository.dart`, and `daily_activities_provider.dart` imports |
| `lib/provider/consultation_provider.dart` | Removed unused `consultation_request_entity.dart` import |
| `lib/provider/therapist_provider.dart` | Removed unused `therapist_personal_info_entity.dart` import |
| `lib/repository/supabase_therapy_repository.dart` | Removed unused `dart:convert`, `flutter/foundation.dart`, `daily_activity_model.dart`, `daily_activity_response_model.dart`, and redundant `therapy_type_entity.dart` (already re-exported by `therapy_entities.dart`) imports |

## Before

```
flutter analyze therapist/
# 114 issues — including 14 unused_import warnings
```

## After

```
flutter analyze therapist/
# 96 issues — all unused_import and unnecessary_import warnings resolved
```

## Checklist

- [x] All removed imports verified as genuinely unused (no references in the file body)
- [x] `flutter analyze` run after changes — no new warnings introduced
- [x] No logic changes — import-only cleanup