### PR TITLE
fix(therapist): Remove spurious @override on non-overriding method

### DIFF
--- a/therapist/lib/repository/supabase_therapist_repository.dart
+++ b/therapist/lib/repository/supabase_therapist_repository.dart
@@ -110,7 +110,6 @@ class SupabaseTherapistRepository implements TherapistRepository {
     }
   }
   
-  @override
   Future<ActionResult> getAllSessionsWithPatientDetails() async {
     try {
       final response = await _supabaseClient.from('session')


### PR DESCRIPTION
## Summary

Closes #198

Removes the incorrect `@override` annotation from `getAllSessionsWithPatientDetails` in `supabase_therapist_repository.dart`.

The `TherapistRepository` abstract interface does **not** declare `getAllSessionsWithPatientDetails`, so the annotation was invalid and triggered the `override_on_non_overriding_member` lint warning.

## Changes

| File | Change |
|------|--------|
| `therapist/lib/repository/supabase_therapist_repository.dart:113` | Removed `@override` annotation |

## Analyzer output

**Before:**
```
warning • The method doesn't override an inherited method • therapist/lib/repository/supabase_therapist_repository.dart:113:3 • override_on_non_overriding_member
```

**After:**
```
(no override_on_non_overriding_member warnings)
```

## Checklist

- [x] Issue linked (#198)
- [x] Single focused change (one annotation removed)
- [x] `flutter analyze therapist/` confirms warning is resolved
- [x] No unrelated changes introduced