### PR TITLE
fix(patient): remove unused and duplicate imports across patient app

### DIFF
--- a/patient/lib/core/repository/auth/auth_repository.dart
+++ b/patient/lib/core/repository/auth/auth_repository.dart
@@ -1,7 +1,4 @@
-import 'package:flutter/material.dart';
 import 'package:patient/core/core.dart';
-import 'package:patient/core/entities/auth_entities/personal_info_entity.dart';
-import 'package:patient/core/result/result.dart';
 
 abstract interface class AuthRepository {
   // The abstract repository class will define the methods that the repository must implement.

--- a/patient/lib/presentation/assessments/assessment_screen.dart
+++ b/patient/lib/presentation/assessments/assessment_screen.dart
@@ -6,7 +6,6 @@ import 'package:patient/presentation/auth/consultation_request_screen.dart';
 import 'package:patient/presentation/widgets/snackbar_service.dart';
 import 'package:patient/provider/assessment_provider.dart';
 import 'package:provider/provider.dart';
-import 'package:patient/presentation/result/result.dart';
 
 
 class AssessmentScreen extends StatefulWidget {

--- a/patient/lib/presentation/auth/consultation_request_screen.dart
+++ b/patient/lib/presentation/auth/consultation_request_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:patient/core/core.dart';
-import 'package:patient/core/repository/auth/auth.dart';
 import 'package:patient/presentation/auth/widgets/consultation_request_card.dart';
-import 'package:patient/presentation/auth/widgets/slot_booking_card.dart';
 import 'package:patient/provider/auth_provider.dart';
 import 'package:provider/provider.dart';
 

--- a/patient/lib/presentation/auth/consultation_slot_booking_screen.dart
+++ b/patient/lib/presentation/auth/consultation_slot_booking_screen.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:patient/presentation/auth/widgets/slot_booking_card.dart';
-import 'package:patient/provider/auth_provider.dart';
-import 'package:provider/provider.dart';
 
 class ConsultationSlotBookingScreen extends StatelessWidget {
   const ConsultationSlotBookingScreen({

--- a/patient/lib/presentation/auth/personal_details_screen.dart
+++ b/patient/lib/presentation/auth/personal_details_screen.dart
@@ -1,15 +1,8 @@
 import 'package:country_picker/country_picker.dart';
 import 'package:flutter/material.dart';
-
-
-import 'package:patient/presentation/assessments/assessment_screen.dart';
 import 'package:patient/presentation/assessments/assessments_list_screen.dart';
-
-import 'package:patient/presentation/home/home_screen.dart';
-
 import 'package:patient/core/core.dart';
 import 'package:patient/model/auth_models/personal_info_model.dart';
-import 'package:patient/presentation/assessments/assessments_list_screen.dart';
 import 'package:patient/presentation/widgets/snackbar_service.dart';
 import 'package:patient/provider/auth_provider.dart';
 import 'package:provider/provider.dart';

--- a/patient/lib/presentation/result/result.dart
+++ b/patient/lib/presentation/result/result.dart
@@ -1,7 +1,4 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:http/http.dart' as http;
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:patient/presentation/result/book_appointment.dart';
 import 'package:patient/presentation/result/widgets/buildresult.dart';  // Import the widgets file

--- a/patient/lib/provider/reports_provider.dart
+++ b/patient/lib/provider/reports_provider.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:patient/core/core.dart';
 
-import '../gen/assets.gen.dart';
-
 enum MilestoneCardType {
   completed,
   missed,

--- a/patient/lib/provider/therapist_provider.dart
+++ b/patient/lib/provider/therapist_provider.dart
@@ -1,9 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:patient/presentation/assessments/models/assessment_card_model.dart';
-import 'package:patient/repository/supabase_assessments_repository.dart';
-
-import 'package:flutter/material.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class TherapistProvider with ChangeNotifier {


### PR DESCRIPTION
## Summary
Resolves #195 by removing all unused and duplicate imports from the patient app.

## Changes Made
- **`auth_repository.dart`**: Removed unused imports of `flutter/material.dart`, `personal_info_entity.dart`, and `result.dart`
- **`assessment_screen.dart`**: Removed unused import of `result.dart`
- **`consultation_request_screen.dart`**: Removed unused imports of `auth.dart` and `slot_booking_card.dart`
- **`consultation_slot_booking_screen.dart`**: Removed unused imports of `auth_provider.dart` and `provider.dart`
- **`personal_details_screen.dart`**: Removed unused imports of `assessment_screen.dart`, `home_screen.dart` and duplicate import of `assessments_list_screen.dart`
- **`result.dart`**: Removed unused imports of `dart:convert`, `flutter_dotenv`, and `http`
- **`reports_provider.dart`**: Removed unused import of `assets.gen.dart`
- **`therapist_provider.dart`**: Removed unused imports of `flutter_dotenv`, `assessment_card_model.dart`, `supabase_assessments_repository.dart` and duplicate import of `flutter/material.dart`

## Testing
- ✅ Ran `flutter analyze` - no unused_import or duplicate_import warnings remain
- ✅ Verified all removed imports are truly unused by checking references
- ✅ Confirmed app functionality remains intact

## Quality Assurance
Each change was carefully reviewed to ensure:
- Only genuinely unused imports were removed
- No breaking changes to existing functionality
- Code remains clean and maintainable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up unused imports across multiple files to improve codebase maintainability and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->