### PR TITLE
feat: implement patient activities backend sync on navigation

### DIFF
--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -55,18 +55,25 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Daily Activities'),
-        centerTitle: true,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios_new_rounded),
-          onPressed: () {
-            context.read<TaskProvider>().updateActivityInBackground();
-            Navigator.pop(context);
-          },
+    return PopScope(
+      canPop: true,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) {
+          context.read<TaskProvider>().updateActivityInBackground();
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Daily Activities'),
+          centerTitle: true,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            onPressed: () {
+              context.read<TaskProvider>().updateActivityInBackground();
+              Navigator.pop(context);
+            },
+          ),
         ),
-      ),
       body: Consumer<TaskProvider>(
         builder: (context, taskProvider, child) {
           final tasks = taskProvider.tasks;
@@ -228,6 +235,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
             ],
           );
         },
+      ),
       ),
     );
   }

--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -62,7 +62,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new_rounded),
           onPressed: () {
-           // context.read<TaskProvider>().updateActivityInBackground(); // TODO: Uncomment this when the backend is ready
+            context.read<TaskProvider>().updateActivityInBackground();
             Navigator.pop(context);
           },
         ),

--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -60,18 +60,16 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
       canPop: false,
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
-        await context.read<TaskProvider>().updateActivityInBackground();
         final taskProvider = context.read<TaskProvider>();
-        if (taskProvider.syncStatus == ApiStatus.failure) {
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('Failed to save your progress'),
-                backgroundColor: Colors.red,
-                duration: Duration(seconds: 2),
-              ),
-            );
-          }
+        await taskProvider.updateActivityInBackground();
+        if (taskProvider.syncStatus == ApiStatus.failure && mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Failed to save your progress'),
+              backgroundColor: Colors.red,
+              duration: Duration(seconds: 2),
+            ),
+          );
         }
         if (mounted) Navigator.pop(context);
       },

--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -2,6 +2,7 @@ import 'package:easy_date_timeline/easy_date_timeline.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../core/core.dart';
 import '../../core/theme/theme.dart';
 import '../../provider/task_provider.dart';
 
@@ -56,11 +57,23 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      canPop: true,
-      onPopInvokedWithResult: (didPop, result) {
-        if (didPop) {
-          context.read<TaskProvider>().updateActivityInBackground();
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        await context.read<TaskProvider>().updateActivityInBackground();
+        final taskProvider = context.read<TaskProvider>();
+        if (taskProvider.syncStatus == ApiStatus.failure) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Failed to save your progress'),
+                backgroundColor: Colors.red,
+                duration: Duration(seconds: 2),
+              ),
+            );
+          }
         }
+        if (mounted) Navigator.pop(context);
       },
       child: Scaffold(
         appBar: AppBar(
@@ -68,10 +81,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
           centerTitle: true,
           leading: IconButton(
             icon: const Icon(Icons.arrow_back_ios_new_rounded),
-            onPressed: () {
-              context.read<TaskProvider>().updateActivityInBackground();
-              Navigator.pop(context);
-            },
+            onPressed: () => Navigator.maybePop(context),
           ),
         ),
       body: Consumer<TaskProvider>(

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -7,6 +7,7 @@ class TaskProvider extends ChangeNotifier {
   DateTime _selectedDate = DateTime.now();
   final PatientRepository _patientRepository;
   ApiStatus _apiStatus = ApiStatus.initial;
+  ApiStatus _syncStatus = ApiStatus.initial;
   String? _activityId;
   String? _activitySetId;
 
@@ -76,6 +77,26 @@ class TaskProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Updates activity completion status in the background (typically before navigation)
+  /// This method syncs the current task completion status to the backend
+  Future<void> updateActivityInBackground() async {
+    if (_allTasks.isEmpty) {
+      return;
+    }
+    try {
+      _syncStatus = ApiStatus.loading;
+      notifyListeners();
+      await updateActivityCompletion(_allTasks);
+      _syncStatus = ApiStatus.success;
+    } catch(e) {
+      _syncStatus = ApiStatus.failure;
+      // Activity data is still available locally - user can retry on return
+    } finally {
+      notifyListeners();
+    }
+  }
+
   int get completedTasksCount => tasks.where((task) => task.isCompleted ?? false).length;
   int get totalTasksCount => tasks.length;
+  ApiStatus get syncStatus => _syncStatus;
 }

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -83,17 +83,12 @@ class TaskProvider extends ChangeNotifier {
     if (_allTasks.isEmpty) {
       return;
     }
-    try {
-      _syncStatus = ApiStatus.loading;
-      notifyListeners();
-      await updateActivityCompletion(_allTasks);
-      _syncStatus = ApiStatus.success;
-    } catch(e) {
-      _syncStatus = ApiStatus.failure;
-      // Activity data is still available locally - user can retry on return
-    } finally {
-      notifyListeners();
-    }
+    _syncStatus = ApiStatus.loading;
+    notifyListeners();
+    await updateActivityCompletion(_allTasks);
+    // updateActivityCompletion sets _apiStatus, copy it to _syncStatus
+    _syncStatus = _apiStatus;
+    notifyListeners();
   }
 
   int get completedTasksCount => tasks.where((task) => task.isCompleted ?? false).length;

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -40,9 +40,13 @@ class TaskProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> updateActivityCompletion(List<PatientTaskModel> tasks) async {
+  Future<void> updateActivityCompletion() async {
     try {
-      final result = await _patientRepository.updateActivityCompletion(tasks: _allTasks, activityId: _activityId, activitySetId: _activitySetId);
+      final result = await _patientRepository.updateActivityCompletion(
+        tasks: _allTasks,
+        activityId: _activityId,
+        activitySetId: _activitySetId,
+      );
       if(result is ActionResultSuccess) {
         _apiStatus = ApiStatus.success;
       } else {
@@ -61,7 +65,7 @@ class TaskProvider extends ChangeNotifier {
     _selectedDate = date;
     notifyListeners();
     if(_allTasks.isNotEmpty) {
-      updateActivityCompletion(_allTasks);
+      updateActivityCompletion();
     }
     getTodayActivities(date: date);
   }
@@ -80,12 +84,12 @@ class TaskProvider extends ChangeNotifier {
   /// Updates activity completion status in the background (typically before navigation)
   /// This method syncs the current task completion status to the backend
   Future<void> updateActivityInBackground() async {
-    if (_allTasks.isEmpty) {
+    if (_allTasks.isEmpty || _syncStatus == ApiStatus.loading) {
       return;
     }
     _syncStatus = ApiStatus.loading;
     notifyListeners();
-    await updateActivityCompletion(_allTasks);
+    await updateActivityCompletion();
     // updateActivityCompletion sets _apiStatus, copy it to _syncStatus
     _syncStatus = _apiStatus;
     notifyListeners();


### PR DESCRIPTION
## 📝 Description

Implements automatic activity completion tracking by syncing task state to the backend when users leave the Daily Activities screen.

## 🔧 Changes Made

- Added `updateActivityInBackground()` method to TaskProvider for backend sync
- Integrated background sync call when user navigates away from Activities screen
- Added sync status tracking (loading/success/failure)
- Fixed pubspec.yaml asset configuration

### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily activity data now syncs automatically in the background when you leave the daily activities screen.
  * Sync status is exposed so the app can indicate synchronization progress to the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->