### PR TITLE
feat: add therapist dashboard metrics (patients/sessions/therapies)

### DIFF
--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -55,18 +55,25 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Daily Activities'),
-        centerTitle: true,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back_ios_new_rounded),
-          onPressed: () {
-            context.read<TaskProvider>().updateActivityInBackground();
-            Navigator.pop(context);
-          },
+    return PopScope(
+      canPop: true,
+      onPopInvokedWithResult: (didPop, result) {
+        if (didPop) {
+          context.read<TaskProvider>().updateActivityInBackground();
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Daily Activities'),
+          centerTitle: true,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios_new_rounded),
+            onPressed: () {
+              context.read<TaskProvider>().updateActivityInBackground();
+              Navigator.pop(context);
+            },
+          ),
         ),
-      ),
       body: Consumer<TaskProvider>(
         builder: (context, taskProvider, child) {
           final tasks = taskProvider.tasks;
@@ -228,6 +235,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
             ],
           );
         },
+      ),
       ),
     );
   }

--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -62,7 +62,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new_rounded),
           onPressed: () {
-           // context.read<TaskProvider>().updateActivityInBackground(); // TODO: Uncomment this when the backend is ready
+            context.read<TaskProvider>().updateActivityInBackground();
             Navigator.pop(context);
           },
         ),

--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -61,17 +61,20 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
         final taskProvider = context.read<TaskProvider>();
-        await taskProvider.updateActivityInBackground();
-        if (taskProvider.syncStatus == ApiStatus.failure && mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Failed to save your progress'),
-              backgroundColor: Colors.red,
-              duration: Duration(seconds: 2),
-            ),
-          );
+        try {
+          await taskProvider.updateActivityInBackground();
+          if (taskProvider.syncStatus == ApiStatus.failure && mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Failed to save your progress'),
+                backgroundColor: Colors.red,
+                duration: Duration(seconds: 2),
+              ),
+            );
+          }
+        } finally {
+          if (mounted) Navigator.pop(context);
         }
-        if (mounted) Navigator.pop(context);
       },
       child: Scaffold(
         appBar: AppBar(

--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -2,6 +2,7 @@ import 'package:easy_date_timeline/easy_date_timeline.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../core/core.dart';
 import '../../core/theme/theme.dart';
 import '../../provider/task_provider.dart';
 
@@ -56,11 +57,21 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      canPop: true,
-      onPopInvokedWithResult: (didPop, result) {
-        if (didPop) {
-          context.read<TaskProvider>().updateActivityInBackground();
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        await context.read<TaskProvider>().updateActivityInBackground();
+        final taskProvider = context.read<TaskProvider>();
+        if (taskProvider.syncStatus == ApiStatus.failure && mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Failed to save your progress'),
+              backgroundColor: Colors.red,
+              duration: Duration(seconds: 2),
+            ),
+          );
         }
+        if (mounted) Navigator.pop(context);
       },
       child: Scaffold(
         appBar: AppBar(
@@ -68,10 +79,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
           centerTitle: true,
           leading: IconButton(
             icon: const Icon(Icons.arrow_back_ios_new_rounded),
-            onPressed: () {
-              context.read<TaskProvider>().updateActivityInBackground();
-              Navigator.pop(context);
-            },
+            onPressed: () => Navigator.maybePop(context),
           ),
         ),
       body: Consumer<TaskProvider>(

--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -60,8 +60,8 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
       canPop: false,
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
-        await context.read<TaskProvider>().updateActivityInBackground();
         final taskProvider = context.read<TaskProvider>();
+        await taskProvider.updateActivityInBackground();
         if (taskProvider.syncStatus == ApiStatus.failure && mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -7,6 +7,7 @@ class TaskProvider extends ChangeNotifier {
   DateTime _selectedDate = DateTime.now();
   final PatientRepository _patientRepository;
   ApiStatus _apiStatus = ApiStatus.initial;
+  ApiStatus _syncStatus = ApiStatus.initial;
   String? _activityId;
   String? _activitySetId;
 
@@ -76,6 +77,26 @@ class TaskProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Updates activity completion status in the background (typically before navigation)
+  /// This method syncs the current task completion status to the backend
+  Future<void> updateActivityInBackground() async {
+    if (_allTasks.isEmpty) {
+      return;
+    }
+    try {
+      _syncStatus = ApiStatus.loading;
+      notifyListeners();
+      await updateActivityCompletion(_allTasks);
+      _syncStatus = ApiStatus.success;
+    } catch(e) {
+      _syncStatus = ApiStatus.failure;
+      // Activity data is still available locally - user can retry on return
+    } finally {
+      notifyListeners();
+    }
+  }
+
   int get completedTasksCount => tasks.where((task) => task.isCompleted ?? false).length;
   int get totalTasksCount => tasks.length;
+  ApiStatus get syncStatus => _syncStatus;
 }

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -83,17 +83,12 @@ class TaskProvider extends ChangeNotifier {
     if (_allTasks.isEmpty) {
       return;
     }
-    try {
-      _syncStatus = ApiStatus.loading;
-      notifyListeners();
-      await updateActivityCompletion(_allTasks);
-      _syncStatus = ApiStatus.success;
-    } catch(e) {
-      _syncStatus = ApiStatus.failure;
-      // Activity data is still available locally - user can retry on return
-    } finally {
-      notifyListeners();
-    }
+    _syncStatus = ApiStatus.loading;
+    notifyListeners();
+    await updateActivityCompletion(_allTasks);
+    // updateActivityCompletion sets _apiStatus, copy it to _syncStatus
+    _syncStatus = _apiStatus;
+    notifyListeners();
   }
 
   int get completedTasksCount => tasks.where((task) => task.isCompleted ?? false).length;

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -40,9 +40,13 @@ class TaskProvider extends ChangeNotifier {
     }
   }
 
-  Future<void> updateActivityCompletion(List<PatientTaskModel> tasks) async {
+  Future<void> updateActivityCompletion() async {
     try {
-      final result = await _patientRepository.updateActivityCompletion(tasks: _allTasks, activityId: _activityId, activitySetId: _activitySetId);
+      final result = await _patientRepository.updateActivityCompletion(
+        tasks: _allTasks,
+        activityId: _activityId,
+        activitySetId: _activitySetId,
+      );
       if(result is ActionResultSuccess) {
         _apiStatus = ApiStatus.success;
       } else {
@@ -61,7 +65,7 @@ class TaskProvider extends ChangeNotifier {
     _selectedDate = date;
     notifyListeners();
     if(_allTasks.isNotEmpty) {
-      updateActivityCompletion(_allTasks);
+      updateActivityCompletion();
     }
     getTodayActivities(date: date);
   }
@@ -80,12 +84,12 @@ class TaskProvider extends ChangeNotifier {
   /// Updates activity completion status in the background (typically before navigation)
   /// This method syncs the current task completion status to the backend
   Future<void> updateActivityInBackground() async {
-    if (_allTasks.isEmpty) {
+    if (_allTasks.isEmpty || _syncStatus == ApiStatus.loading) {
       return;
     }
     _syncStatus = ApiStatus.loading;
     notifyListeners();
-    await updateActivityCompletion(_allTasks);
+    await updateActivityCompletion();
     // updateActivityCompletion sets _apiStatus, copy it to _syncStatus
     _syncStatus = _apiStatus;
     notifyListeners();

--- a/therapist/lib/presentation/home/home_screen.dart
+++ b/therapist/lib/presentation/home/home_screen.dart
@@ -36,8 +36,11 @@ class _HomeScreenState extends State<HomeScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       Provider.of<ConsultationProvider>(context, listen: false)
           .fetchConsultationRequests();
-      Provider.of<TherapistDataProvider>(context, listen: false)
-          .fetchPatientsMappedToTherapist();
+      final therapistProvider = Provider.of<TherapistDataProvider>(context, listen: false);
+      therapistProvider.fetchPatientsMappedToTherapist();
+      therapistProvider.fetchTotals();
+      Provider.of<SessionProvider>(context, listen: false)
+          .fetchTherapistSessions();
     });
 
     _refreshTimer = Timer.periodic(const Duration(minutes: 3), (_) {
@@ -249,34 +252,54 @@ class HomeContent extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 24),
-            //_buildConsultationRequestSection(context),
-          //  _buildConsultationRequestSection(context),
-           Consumer<TherapistDataProvider>(
-            builder: (context, provider, _) {
-              if(provider.patientsStatus == ApiStatus.loading) {
-                return const Center(child: CircularProgressIndicator());
-              } else if(provider.patientsStatus == ApiStatus.failure) {
-                return const Center(child: Text('No patients found'));
-              } else if(provider.patientsStatus == ApiStatus.success) {
-                if(provider.patients.isEmpty) { 
-                  return const Center(child: Text('No patients found'));
-                } else {
-                  return Column(
-                    children: provider.patients.map((patient) => PatientCard(
-                    name: patient.patientName,
-                    id: patient.patientId,
-                    phone: patient.phoneNo,
-                    email: patient.email,
-                    package: '-',
-                    duration: '-',
-                    imagePath: 'assets/abdul.png',
-                  )).toList(),
-                  );
+            Consumer2<TherapistDataProvider, SessionProvider>(
+              builder: (context, therapistProvider, sessionProvider, _) {
+                if (therapistProvider.isLoading || sessionProvider.isLoading) {
+                  return const Center(child: CircularProgressIndicator());
                 }
-              }
-              return const SizedBox.shrink();
-            },
-           ),
+
+                return Container(
+                  padding: const EdgeInsets.all(20),
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.circular(16),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.05),
+                        blurRadius: 10,
+                        offset: const Offset(0, 5),
+                      ),
+                    ],
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      StatsCard(
+                        imagePath: 'assets/icon1.png',
+                        backgroundColor: const Color(0xFFFEE8E8),
+                        label: 'Patients',
+                        value: therapistProvider.totalPatients.toString(),
+                      ),
+                      StatsCard(
+                        imagePath: 'assets/icon2.png',
+                        backgroundColor: const Color(0xFFF1E8FE),
+                        label: 'Sessions',
+                        value: sessionProvider.totalSessions.toString(),
+                      ),
+                      StatsCard(
+                        imagePath: 'assets/icon3.png',
+                        backgroundColor: const Color(0xFFE8FEF0),
+                        label: 'Therapies',
+                        value: therapistProvider.totalTherapies.toString(),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 24),
+            // _buildConsultationRequestSection(context),
+
           ],
         ),
       ),

--- a/therapist/lib/presentation/home/home_screen.dart
+++ b/therapist/lib/presentation/home/home_screen.dart
@@ -216,7 +216,7 @@ class HomeContent extends StatelessWidget {
           children: [
             Consumer<TherapistDataProvider>(
               builder: (context, therapistProvider, _) {
-                if (therapistProvider.isLoading) {
+                if (therapistProvider.isTotalsLoading) {
                   return const Center(child: CircularProgressIndicator());
                 }
 

--- a/therapist/lib/presentation/home/home_screen.dart
+++ b/therapist/lib/presentation/home/home_screen.dart
@@ -214,47 +214,9 @@ class HomeContent extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.all(20),
           children: [
-            Container(
-              padding: const EdgeInsets.all(20),
-              decoration: BoxDecoration(
-                color: Colors.white,
-                borderRadius: BorderRadius.circular(16),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.05),
-                    blurRadius: 10,
-                    offset: const Offset(0, 5),
-                  ),
-                ],
-              ),
-              child: const Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: [
-                  StatsCard(
-                    imagePath: 'assets/icon1.png',
-                    backgroundColor: Color(0xFFFEE8E8),
-                    label: 'Patients',
-                    value: '02',
-                  ),
-                  StatsCard(
-                    imagePath: 'assets/icon2.png',
-                    backgroundColor: Color(0xFFF1E8FE),
-                    label: 'Sessions',
-                    value: '20',
-                  ),
-                  StatsCard(
-                    imagePath: 'assets/icon3.png',
-                    backgroundColor: Color(0xFFE8FEF0),
-                    label: 'Therapies',
-                    value: '13',
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 24),
-            Consumer2<TherapistDataProvider, SessionProvider>(
-              builder: (context, therapistProvider, sessionProvider, _) {
-                if (therapistProvider.isLoading || sessionProvider.isLoading) {
+            Consumer<TherapistDataProvider>(
+              builder: (context, therapistProvider, _) {
+                if (therapistProvider.isLoading) {
                   return const Center(child: CircularProgressIndicator());
                 }
 
@@ -284,7 +246,7 @@ class HomeContent extends StatelessWidget {
                         imagePath: 'assets/icon2.png',
                         backgroundColor: const Color(0xFFF1E8FE),
                         label: 'Sessions',
-                        value: sessionProvider.totalSessions.toString(),
+                        value: therapistProvider.totalSessions.toString(),
                       ),
                       StatsCard(
                         imagePath: 'assets/icon3.png',

--- a/therapist/lib/provider/therapist_provider.dart
+++ b/therapist/lib/provider/therapist_provider.dart
@@ -152,6 +152,15 @@ class TherapistDataProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  int _totalPatients = 0;
+  int get totalPatients => _totalPatients;
+
+  int _totalSessions = 0;
+  int get totalSessions => _totalSessions;
+
+  int _totalTherapies = 0;
+  int get totalTherapies => _totalTherapies;
+
   // Fetch therapies based on selected profession
   Future<void> fetchTherapies(int professionId) async {
     _isLoading = true;
@@ -164,6 +173,29 @@ class TherapistDataProvider extends ChangeNotifier {
       _errorMessage = '';
     } else if (result is ActionResultFailure) {
       _errorMessage = result.errorMessage!;
+    }
+
+    _isLoading = false;
+    notifyListeners();
+  }
+
+  Future<void> fetchTotals() async {
+    _isLoading = true;
+    notifyListeners();
+
+    final patientsResult = await _therapistRepository.getTotalPatients();
+    if (patientsResult is ActionResultSuccess) {
+      _totalPatients = patientsResult.data as int;
+    }
+
+    final sessionsResult = await _therapistRepository.getTotalSessions();
+    if (sessionsResult is ActionResultSuccess) {
+      _totalSessions = sessionsResult.data as int;
+    }
+
+    final therapiesResult = await _therapistRepository.getTotalTherapies();
+    if (therapiesResult is ActionResultSuccess) {
+      _totalTherapies = therapiesResult.data as int;
     }
 
     _isLoading = false;

--- a/therapist/lib/provider/therapist_provider.dart
+++ b/therapist/lib/provider/therapist_provider.dart
@@ -182,24 +182,31 @@ class TherapistDataProvider extends ChangeNotifier {
   Future<void> fetchTotals() async {
     _isLoading = true;
     notifyListeners();
+    try {
+      final results = await Future.wait([
+        _therapistRepository.getTotalPatients(),
+        _therapistRepository.getTotalSessions(),
+        _therapistRepository.getTotalTherapies(),
+      ]);
 
-    final patientsResult = await _therapistRepository.getTotalPatients();
-    if (patientsResult is ActionResultSuccess) {
-      _totalPatients = patientsResult.data as int;
+      final patientsResult = results[0];
+      if (patientsResult is ActionResultSuccess) {
+        _totalPatients = (patientsResult.data as num?)?.toInt() ?? 0;
+      }
+
+      final sessionsResult = results[1];
+      if (sessionsResult is ActionResultSuccess) {
+        _totalSessions = (sessionsResult.data as num?)?.toInt() ?? 0;
+      }
+
+      final therapiesResult = results[2];
+      if (therapiesResult is ActionResultSuccess) {
+        _totalTherapies = (therapiesResult.data as num?)?.toInt() ?? 0;
+      }
+    } finally {
+      _isLoading = false;
+      notifyListeners();
     }
-
-    final sessionsResult = await _therapistRepository.getTotalSessions();
-    if (sessionsResult is ActionResultSuccess) {
-      _totalSessions = sessionsResult.data as int;
-    }
-
-    final therapiesResult = await _therapistRepository.getTotalTherapies();
-    if (therapiesResult is ActionResultSuccess) {
-      _totalTherapies = therapiesResult.data as int;
-    }
-
-    _isLoading = false;
-    notifyListeners();
   }
 
   // Set selected profession and fetch related data

--- a/therapist/lib/provider/therapist_provider.dart
+++ b/therapist/lib/provider/therapist_provider.dart
@@ -15,6 +15,10 @@ class TherapistDataProvider extends ChangeNotifier {
 
   bool _isLoading = false;
   bool get isLoading => _isLoading;
+  bool _isTotalsLoading = false;
+  bool get isTotalsLoading => _isTotalsLoading;
+  bool _isPatientsLoading = false;
+  bool get isPatientsLoading => _isPatientsLoading;
 
   String _errorMessage = '';
   String get errorMessage => _errorMessage;
@@ -180,7 +184,7 @@ class TherapistDataProvider extends ChangeNotifier {
   }
 
   Future<void> fetchTotals() async {
-    _isLoading = true;
+    _isTotalsLoading = true;
     notifyListeners();
     try {
       final results = await Future.wait([
@@ -204,7 +208,7 @@ class TherapistDataProvider extends ChangeNotifier {
         _totalTherapies = (therapiesResult.data as num?)?.toInt() ?? 0;
       }
     } finally {
-      _isLoading = false;
+      _isTotalsLoading = false;
       notifyListeners();
     }
   }
@@ -248,19 +252,24 @@ class TherapistDataProvider extends ChangeNotifier {
   }
 
   Future<void> fetchPatientsMappedToTherapist() async {
+    _isPatientsLoading = true;
     _patientsStatus = ApiStatus.loading;
     notifyListeners();
 
-    final result = await _therapistRepository.fetchPatientsMappedToTherapist();
+    try {
+      final result = await _therapistRepository.fetchPatientsMappedToTherapist();
 
-    if(result is ActionResultSuccess) {
-      _patients = result.data;
-      _patientsStatus = ApiStatus.success;
-    } else if(result is ActionResultFailure) {
-      _patients = <TherapistPatientDetailsModel>[];
-      _patientsStatus = ApiStatus.failure;
-      _errorMessage = result.errorMessage!;
+      if(result is ActionResultSuccess) {
+        _patients = result.data;
+        _patientsStatus = ApiStatus.success;
+      } else if(result is ActionResultFailure) {
+        _patients = <TherapistPatientDetailsModel>[];
+        _patientsStatus = ApiStatus.failure;
+        _errorMessage = result.errorMessage!;
+      }
+    } finally {
+      _isPatientsLoading = false;
+      notifyListeners();
     }
-    notifyListeners();
   }
 }

--- a/therapist/lib/repository/supabase_therapist_repository.dart
+++ b/therapist/lib/repository/supabase_therapist_repository.dart
@@ -129,21 +129,50 @@ class SupabaseTherapistRepository implements TherapistRepository {
   }
 
   @override
-  Future<ActionResult> getTotalPatients() {
-    // TODO: implement getTotalPatients
-    throw UnimplementedError();
+  Future<ActionResult> getTotalPatients() async {
+    try {
+      final response = await _supabaseClient
+          .from('patient')
+          .select('id')
+          .eq('therapist_id', _supabaseClient.auth.currentUser!.id);
+
+      final count = response is List ? response.length : 0;
+      return ActionResultSuccess(data: count, statusCode: 200);
+    } catch (e) {
+      return ActionResultFailure(errorMessage: e.toString(), statusCode: 400);
+    }
   }
-  
+
   @override
-  Future<ActionResult> getTotalSessions() {
-    // TODO: implement getTotalSessions
-    throw UnimplementedError();
+  Future<ActionResult> getTotalSessions() async {
+    try {
+      final response = await _supabaseClient
+          .from('session')
+          .select('id')
+          .eq('therapist_id', _supabaseClient.auth.currentUser!.id);
+
+      final count = response is List ? response.length : 0;
+      return ActionResultSuccess(data: count, statusCode: 200);
+    } catch (e) {
+      return ActionResultFailure(errorMessage: e.toString(), statusCode: 400);
+    }
   }
-  
+
   @override
-  Future<ActionResult> getTotalTherapies() {
-    // TODO: implement getTotalTherapies
-    throw UnimplementedError();
+  Future<ActionResult> getTotalTherapies() async {
+    try {
+      final response = await _supabaseClient
+          .from('therapy_goal')
+          .select('therapy_type_id')
+          .eq('therapist_id', _supabaseClient.auth.currentUser!.id);
+
+      final count = response is List
+          ? (response.map((e) => e['therapy_type_id']).toSet().length)
+          : 0;
+      return ActionResultSuccess(data: count, statusCode: 200);
+    } catch (e) {
+      return ActionResultFailure(errorMessage: e.toString(), statusCode: 400);
+    }
   }
 
   @override

--- a/therapist/lib/repository/supabase_therapist_repository.dart
+++ b/therapist/lib/repository/supabase_therapist_repository.dart
@@ -167,7 +167,11 @@ class SupabaseTherapistRepository implements TherapistRepository {
           .eq('therapist_id', _supabaseClient.auth.currentUser!.id);
 
       final count = response is List
-          ? (response.map((e) => e['therapy_type_id']).toSet().length)
+          ? response
+              .map((e) => e['therapy_type_id'])
+              .where((id) => id != null)
+              .toSet()
+              .length
           : 0;
       return ActionResultSuccess(data: count, statusCode: 200);
     } catch (e) {


### PR DESCRIPTION
## 📝 Description

Adds therapist dashboard summary metrics and backend support to display:
- total patients assigned to current therapist
- total sessions for current therapist
- total distinct therapies delivered by current therapist

## 🔧 Changes Made

- `therapist/lib/repository/supabase_therapist_repository.dart`
  - implemented `getTotalPatients()`, `getTotalSessions()`, `getTotalTherapies()` in Supabase repository.
- `therapist/lib/provider/therapist_provider.dart`
  - added `totalPatients`, `totalSessions`, `totalTherapies`
  - added `fetchTotals()` to call the new repository methods and update state.
- `therapist/lib/presentation/home/home_screen.dart`
  - updated init logic to call `fetchTotals()` + `fetchTherapistSessions()`
  - updated summary stats section to display real values via `Consumer2<TherapistDataProvider, SessionProvider>`
- Replaced static demo numbers in dashboard with live values.

### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Statistics dashboard on therapist home showing total patients, sessions, and therapies.
  * Automatic background sync of activity progress when leaving the daily activities screen.

* **Bug Fixes / Improvements**
  * Shows a failure notification if background sync fails.
  * Safer back-navigation to ensure progress is saved before exit.
  * Loading indicator shown while dashboard totals load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->