### PR TITLE
fix: correct field mapping in child mode onboarding for phone, country and guardian relation

### DIFF
--- a/patient/lib/presentation/auth/personal_details_screen.dart
+++ b/patient/lib/presentation/auth/personal_details_screen.dart
@@ -91,11 +91,13 @@ class _PersonalDetailsScreenState extends State<PersonalDetailsScreen> {
           : adultNameController.text,
       age: isAssessmentForChild ? parseAge(childAgeController.text) : parseAge(adultAgeController.text),
       isAdult: isAssessmentForChild ? isAdult(childAgeController.text) : isAdult(adultAgeController.text),
-      phoneNo: phoneController.text,
+      phoneNo: isAssessmentForChild ? guardianPhoneController.text : phoneController.text,
       email: '',
       guardianName: isAssessmentForChild ? adultNameController.text : '',
-      guardianRelation: isAssessmentForChild ? guardianPhoneController.text : phoneController.text,
-      country: selectedCountry?.displayName ?? '',
+      guardianRelation: isAssessmentForChild ? selectedRelation : '',
+      country: isAssessmentForChild
+          ? selectedChildCountry?.displayName ?? ''
+          : selectedCountry?.displayName ?? '',
       gender: isAssessmentForChild ? selectedChildGender ?? '' : selectedGender ?? '',
     );
   }
@@ -110,6 +112,18 @@ class _PersonalDetailsScreenState extends State<PersonalDetailsScreen> {
           onPressed: () {
 
             if (_formKey.currentState?.validate() ?? false) {
+              if (isAssessmentForChild && selectedRelation.isEmpty) {
+                setState(() {
+                  _validationErrors['relation'] = 'Please select your relation with the patient';
+                });
+                return;
+              }
+              if (isAssessmentForChild && (selectedChildGender == null || selectedChildGender!.isEmpty)) {
+                setState(() {
+                  _validationErrors['gender'] = 'Please select patient gender';
+                });
+                return;
+              }
               final personalInfoModel = getPersonalInfo;
               final authProvider = context.read<AuthProvider>();
               authProvider.storePatientPersonalInfo(personalInfoModel);

--- a/patient/lib/presentation/auth/personal_details_screen.dart
+++ b/patient/lib/presentation/auth/personal_details_screen.dart
@@ -113,15 +113,11 @@ class _PersonalDetailsScreenState extends State<PersonalDetailsScreen> {
 
             if (_formKey.currentState?.validate() ?? false) {
               if (isAssessmentForChild && selectedRelation.isEmpty) {
-                setState(() {
-                  _validationErrors['relation'] = 'Please select your relation with the patient';
-                });
+                SnackbarService.showError('Please select your relation with the patient');
                 return;
               }
               if (isAssessmentForChild && (selectedChildGender == null || selectedChildGender!.isEmpty)) {
-                setState(() {
-                  _validationErrors['gender'] = 'Please select patient gender';
-                });
+                SnackbarService.showError('Please select patient gender');
                 return;
               }
               final personalInfoModel = getPersonalInfo;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #215 


## 📝 Description

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->
In child mode on the Personal Details onboarding screen, three fields in the `getPersonalInfo` getter were incorrectly mapped, causing corrupted data to be saved to Supabase on every child-mode registration. Additionally, the Relation and Patient Gender dropdowns were not part of the form validation pipeline, allowing silent submission with empty required fields.


## 🔧 Changes Made

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- Fixed `phoneNo` to read from `guardianPhoneController` in child mode instead of always reading the adult form's `phoneController`
- Fixed `guardianRelation` to read from `selectedRelation` (the dropdown value) instead of `guardianPhoneController.text`
- Fixed `country` to read from `selectedChildCountry` in child mode instead of always reading `selectedCountry` from the adult form
- Added pre-submission validation for `selectedRelation` and `selectedChildGender` in the `onPressed` handler since these are `DropdownMenu` widgets and are skipped by `_formKey.currentState?.validate()`

## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->
Not applicable. The bug was in data written to Supabase, not visible in the UI.

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: NONE


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation for child assessments: require guardian relation before continuing.
  * Require child gender confirmation with clear error feedback preventing submission.
  * Fixed mapping of phone, relation and country fields to use child-specific inputs when assessment is for a child, preserving adult flow otherwise.
  * Enhanced inline error messages to guide correct input for child assessments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->