### PR TITLE
fix: persist daily activity completions to Supabase on toggle and screen exit

### DIFF
--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:easy_date_timeline/easy_date_timeline.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -43,7 +45,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.paused) {
-      context.read<TaskProvider>().saveAndFlush();
+      unawaited(context.read<TaskProvider>().saveAndFlush());
     }
   }
 

--- a/patient/lib/presentation/activities/daily_activities_screen.dart
+++ b/patient/lib/presentation/activities/daily_activities_screen.dart
@@ -13,7 +13,7 @@ class DailyActivitiesScreen extends StatefulWidget {
 }
 
 class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
   late DateTime today;
   late AnimationController _progressController;
   late Animation<double> _progressAnimation;
@@ -22,6 +22,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       context.read<TaskProvider>().getTodayActivities();
     });
@@ -34,8 +35,16 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _progressController.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.paused) {
+      context.read<TaskProvider>().saveAndFlush();
+    }
   }
 
   void _animateProgress(double end) {
@@ -55,15 +64,22 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        await context.read<TaskProvider>().saveAndFlush();
+        if (context.mounted) Navigator.of(context).pop();
+      },
+      child: Scaffold(
       appBar: AppBar(
         title: const Text('Daily Activities'),
         centerTitle: true,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new_rounded),
-          onPressed: () {
-           // context.read<TaskProvider>().updateActivityInBackground(); // TODO: Uncomment this when the backend is ready
-            Navigator.pop(context);
+          onPressed: () async {
+            await context.read<TaskProvider>().saveAndFlush();
+            if (context.mounted) Navigator.of(context).pop();
           },
         ),
       ),
@@ -229,6 +245,7 @@ class _DailyActivitiesScreenState extends State<DailyActivitiesScreen>
           );
         },
       ),
+    ),
     );
   }
 }

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -59,7 +59,9 @@ class TaskProvider extends ChangeNotifier {
 
   DateTime get selectedDate => _selectedDate;
 
-  void setSelectedDate(DateTime date) async {
+  Future<void> setSelectedDate(DateTime date) async {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
     _selectedDate = date;
     notifyListeners();
     if (_allTasks.isNotEmpty) {
@@ -79,8 +81,9 @@ class TaskProvider extends ChangeNotifier {
     notifyListeners();
 
     _debounceTimer?.cancel();
+    final snapshot = List<PatientTaskModel>.from(_allTasks);
     _debounceTimer = Timer(const Duration(milliseconds: 1500), () {
-      updateActivityCompletion(_allTasks);
+      unawaited(updateActivityCompletion(snapshot));
     });
   }
 
@@ -94,7 +97,10 @@ class TaskProvider extends ChangeNotifier {
 
   @override
   void dispose() {
-    _debounceTimer?.cancel();
+    if (_debounceTimer?.isActive ?? false) {
+      _debounceTimer?.cancel();
+      unawaited(updateActivityCompletion(_allTasks));
+    }
     super.dispose();
   }
 

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -12,6 +12,7 @@ class TaskProvider extends ChangeNotifier {
   String? _activityId;
   String? _activitySetId;
   Timer? _debounceTimer;
+  bool _isDisposed = false;
 
   TaskProvider({
     required PatientRepository patientRepository,
@@ -44,7 +45,7 @@ class TaskProvider extends ChangeNotifier {
 
   Future<void> updateActivityCompletion(List<PatientTaskModel> tasks) async {
     try {
-      final result = await _patientRepository.updateActivityCompletion(tasks: _allTasks, activityId: _activityId, activitySetId: _activitySetId);
+      final result = await _patientRepository.updateActivityCompletion(tasks: tasks, activityId: _activityId, activitySetId: _activitySetId);
       if(result is ActionResultSuccess) {
         _apiStatus = ApiStatus.success;
       } else {
@@ -53,7 +54,7 @@ class TaskProvider extends ChangeNotifier {
     } catch(e) {
       _apiStatus = ApiStatus.failure;
     } finally {
-      notifyListeners();
+      if (!_isDisposed) notifyListeners();
     }
   }
 
@@ -67,7 +68,7 @@ class TaskProvider extends ChangeNotifier {
     if (_allTasks.isNotEmpty) {
       await updateActivityCompletion(_allTasks);
     }
-    getTodayActivities(date: date);
+    await getTodayActivities(date: date);
   }
 
   List<PatientTaskModel> get tasks {
@@ -97,10 +98,8 @@ class TaskProvider extends ChangeNotifier {
 
   @override
   void dispose() {
-    if (_debounceTimer?.isActive ?? false) {
-      _debounceTimer?.cancel();
-      unawaited(updateActivityCompletion(_allTasks));
-    }
+    _isDisposed = true;
+    _debounceTimer?.cancel();
     super.dispose();
   }
 

--- a/patient/lib/provider/task_provider.dart
+++ b/patient/lib/provider/task_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:patient/core/core.dart';
 import 'package:patient/model/task_model.dart';
@@ -9,6 +11,7 @@ class TaskProvider extends ChangeNotifier {
   ApiStatus _apiStatus = ApiStatus.initial;
   String? _activityId;
   String? _activitySetId;
+  Timer? _debounceTimer;
 
   TaskProvider({
     required PatientRepository patientRepository,
@@ -56,11 +59,11 @@ class TaskProvider extends ChangeNotifier {
 
   DateTime get selectedDate => _selectedDate;
 
-  void setSelectedDate(DateTime date) {
+  void setSelectedDate(DateTime date) async {
     _selectedDate = date;
     notifyListeners();
-    if(_allTasks.isNotEmpty) {
-      updateActivityCompletion(_allTasks);
+    if (_allTasks.isNotEmpty) {
+      await updateActivityCompletion(_allTasks);
     }
     getTodayActivities(date: date);
   }
@@ -69,11 +72,30 @@ class TaskProvider extends ChangeNotifier {
     return _allTasks;
   }
 
-  void toggleTaskCompletion(String activityId, bool isCompleted) async {
+  void toggleTaskCompletion(String activityId, bool isCompleted) {
     _allTasks = _allTasks.map(
       (task) => task.activityId == activityId ? task.copyWith(isCompleted: isCompleted) : task)
       .toList();
     notifyListeners();
+
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(milliseconds: 1500), () {
+      updateActivityCompletion(_allTasks);
+    });
+  }
+
+  Future<void> saveAndFlush() async {
+    _debounceTimer?.cancel();
+    _debounceTimer = null;
+    if (_allTasks.isNotEmpty) {
+      await updateActivityCompletion(_allTasks);
+    }
+  }
+
+  @override
+  void dispose() {
+    _debounceTimer?.cancel();
+    super.dispose();
   }
 
   int get completedTasksCount => tasks.where((task) => task.isCompleted ?? false).length;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #217 


## 📝 Description

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->
`toggleTaskCompletion()` was only updating in-memory state and calling `notifyListeners()` with no Supabase write. The only save path in the codebase was a commented-out TODO pointing to a method that never existed. This means every patient's activity completion history was never actually saved - progress reset silently on every back navigation or restart.

## 🔧 Changes Made

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- Added debounced `updateActivityCompletion()` call inside `toggleTaskCompletion()` so 
  each checkbox toggle persists to Supabase after 1.5s
- Added `saveAndFlush()` method that cancels the debounce timer and immediately awaits 
  `updateActivityCompletion()` for use on screen exit
- Added `dispose()` override in `TaskProvider` to cancel any pending debounce timer on cleanup
- Fixed `setSelectedDate()` to `await` the completion update before fetching new activities, 
  eliminating the race condition where a fresh DB read could overwrite unsaved state
- Wrapped the screen `Scaffold` in `PopScope` so system back gesture calls `saveAndFlush()` before popping
- Fixed the `AppBar` back button to also call `saveAndFlush()` before popping
- Added `WidgetsBindingObserver` to call `saveAndFlush()` when the app is backgrounded
- Removed the stale commented-out `updateActivityInBackground` TODO line


## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->
Not applicable. The fix is in data written to Supabase, not visible in the UI.

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: NONE


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks now automatically save when the app is paused or closed.
  * Back button saves your progress before exiting the screen.
  * Pending changes are reliably flushed when leaving the screen.

* **Performance**
  * Task completions are batched (debounced) to make toggling multiple tasks feel faster and more responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->