### PR TITLE
fix: pass resolved therapist ID and time slot to Supabase on appointment booking

### DIFF
--- a/patient/lib/core/entities/patient_entities/patient_schedule_appointment_entity.dart
+++ b/patient/lib/core/entities/patient_entities/patient_schedule_appointment_entity.dart
@@ -50,7 +50,7 @@ class PatientScheduleAppointmentEntity with PatientScheduleAppointmentEntityMapp
       duration: duration,
       isConsultation: false,
       status: 'pending',
-      name: serviceType,
+      name: appointmentName,
     );
   }
 

--- a/patient/lib/model/patient_models/patient_schedule_appointment_model.dart
+++ b/patient/lib/model/patient_models/patient_schedule_appointment_model.dart
@@ -31,7 +31,7 @@ class PatientScheduleAppointmentModel
       patientId: patientId,
       therapistId: therapistId,
       serviceType: serviceType,
-      timestamp: DateTime.parse(date),
+      timestamp: DateTime.parse(date).toLocal(),
       mode: 1,
       duration: 30,
       appointmentName: appointmentName,

--- a/patient/lib/provider/appointments_provider.dart
+++ b/patient/lib/provider/appointments_provider.dart
@@ -29,6 +29,9 @@ class AppointmentsProvider extends ChangeNotifier {
   String _selectedService = 'Consultation';
   DateTime? _selectedDate;
   String _selectedTimeSlot = '';
+  String _therapistId = '';
+  bool _isSubmitting = false;
+  String? _bookingError;
 
   // Getters
   List<String> get serviceTypes => _serviceTypes;
@@ -39,6 +42,9 @@ class AppointmentsProvider extends ChangeNotifier {
   bool get hasAppointments => _appointments.isNotEmpty;
   List<String> get availableTimeSlots => _availableTimeSlots;
   bool get isFetchingSlots => _isFetchingSlots;
+  bool get isSubmitting => _isSubmitting;
+  String? get bookingError => _bookingError;
+  String get therapistId => _therapistId;
  // List<Map<String, dynamic>> get timeSlots => List.unmodifiable(_timeSlots);
 
 
@@ -126,6 +132,8 @@ class AppointmentsProvider extends ChangeNotifier {
 
       final result = await _authRepository.getAvailableBookingSlotsForTherapist(
         therapistId, date, startTime, endTime);
+      _therapistId = therapistId ?? '';
+      notifyListeners();
 
       if (token != _fetchToken) return;
 
@@ -174,28 +182,65 @@ class AppointmentsProvider extends ChangeNotifier {
 
   /// Creates a new appointment and resets selection. Future: Save to Supabase.
   Future<bool> createAppointment() async {
+    if (_isSubmitting) return false;
+
+    _bookingError = null;
+
+    if (_selectedDate == null) {
+      _bookingError = 'Please select a date before booking.';
+      notifyListeners();
+      return false;
+    }
+
+    if (_selectedTimeSlot.isEmpty) {
+      _bookingError = 'Please select a time slot before booking.';
+      notifyListeners();
+      return false;
+    }
+
+    if (_therapistId.isEmpty) {
+      _bookingError = 'No therapist assigned. Please contact support.';
+      notifyListeners();
+      return false;
+    }
+
+    _isSubmitting = true;
+    notifyListeners();
+
     try {
-      final appointmentModel = PatientScheduleAppointmentModel(
-        patientId: Supabase.instance.client.auth.currentUser!.id,
-        therapistId: '', 
-        serviceType: _selectedService, 
-        date: _selectedDate!.toIso8601String(),
-        slot: _selectedTimeSlot, 
-        appointmentName: 'Appointment with the Therapist'
-      );
+      final slotDateTime = _parseSlotToDateTime(_selectedTimeSlot, _selectedDate!);
 
-      final result = await _authRepository.bookConsultation(appointmentModel.toEntity().toConsultationRequestEntity());
-
-
-      if(result is ActionResultSuccess) {
-        return true;
-      } else {
+      if (slotDateTime == null) {
+        _bookingError = 'Selected time slot is invalid. Please choose another slot.';
         return false;
       }
-    } catch(e) {
+
+      final appointmentModel = PatientScheduleAppointmentModel(
+        patientId: Supabase.instance.client.auth.currentUser!.id,
+        therapistId: _therapistId,
+        serviceType: _selectedService,
+        date: slotDateTime.toIso8601String(),
+        slot: _selectedTimeSlot,
+        appointmentName: 'Appointment with the Therapist',
+      );
+
+      final result = await _authRepository.bookConsultation(
+        appointmentModel.toEntity().toConsultationRequestEntity(),
+      );
+
+      if (result is ActionResultSuccess) {
+        _bookingError = null;
+        return true;
+      } else {
+        _bookingError = 'Booking failed. Please try again.';
+        return false;
+      }
+    } catch (e) {
+      _bookingError = 'An unexpected error occurred. Please try again.';
       print(e);
       return false;
     } finally {
+      _isSubmitting = false;
       fetchAllAppointments();
       notifyListeners();
     }
@@ -224,6 +269,32 @@ class AppointmentsProvider extends ChangeNotifier {
     _selectedService = 'Consultation';
     _selectedDate = null;
     _selectedTimeSlot = '';
+    _therapistId = '';
+    _isSubmitting = false;
+    _bookingError = null;
     notifyListeners();
+  }
+  DateTime? _parseSlotToDateTime(String slot, DateTime date) {
+    try {
+      final trimmed = slot.trim();
+      if (trimmed.isEmpty) return null;
+      final parts = trimmed.split(' ');
+      final timeParts = parts[0].split(':');
+      if (timeParts.length < 2) return null;
+      final parsedHour = int.tryParse(timeParts[0]);
+      final parsedMinute = int.tryParse(timeParts[1]);
+      if (parsedHour == null || parsedMinute == null) return null;
+      if (parsedHour < 0 || parsedHour > 23) return null;
+      if (parsedMinute < 0 || parsedMinute > 59) return null;
+      int hour = parsedHour;
+      final minute = parsedMinute;
+      final isPM = parts.length > 1 && parts[1].toUpperCase() == 'PM';
+      final isAM = parts.length > 1 && parts[1].toUpperCase() == 'AM';
+      if (isPM && hour != 12) hour += 12;
+      if (isAM && hour == 12) hour = 0;
+      return DateTime(date.year, date.month, date.day, hour, minute);
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/patient/lib/provider/appointments_provider.dart
+++ b/patient/lib/provider/appointments_provider.dart
@@ -85,6 +85,7 @@ class AppointmentsProvider extends ChangeNotifier {
       final supabase = Supabase.instance.client;
       final currentUser = supabase.auth.currentUser;
       if (currentUser == null) {
+        _therapistId = '';
         availableTimeSlots = [];
         return;
       }
@@ -115,6 +116,7 @@ class AppointmentsProvider extends ChangeNotifier {
       }
 
       if (therapistId == null || therapistId.isEmpty) {
+        _therapistId = '';
         availableTimeSlots = [];
         return;
       }
@@ -145,6 +147,7 @@ class AppointmentsProvider extends ChangeNotifier {
     } catch(e) {
       print(e);
       if (token == _fetchToken) {
+        _therapistId = '';
         availableTimeSlots = [];
       }
     } finally {
@@ -200,6 +203,12 @@ class AppointmentsProvider extends ChangeNotifier {
 
     if (_isFetchingSlots) {
       _bookingError = 'Please wait while available slots are loading.';
+      notifyListeners();
+      return false;
+    }
+
+    if (!_availableTimeSlots.contains(_selectedTimeSlot)) {
+      _bookingError = 'Selected time slot is no longer available. Please choose another slot.';
       notifyListeners();
       return false;
     }

--- a/patient/lib/provider/appointments_provider.dart
+++ b/patient/lib/provider/appointments_provider.dart
@@ -132,10 +132,10 @@ class AppointmentsProvider extends ChangeNotifier {
 
       final result = await _authRepository.getAvailableBookingSlotsForTherapist(
         therapistId, date, startTime, endTime);
+      if (token != _fetchToken) return;
+
       _therapistId = therapistId ?? '';
       notifyListeners();
-
-      if (token != _fetchToken) return;
 
       if(result is ActionResultSuccess) {
         availableTimeSlots = result.data as List<String>;
@@ -198,6 +198,12 @@ class AppointmentsProvider extends ChangeNotifier {
       return false;
     }
 
+    if (_isFetchingSlots) {
+      _bookingError = 'Please wait while available slots are loading.';
+      notifyListeners();
+      return false;
+    }
+
     if (_therapistId.isEmpty) {
       _bookingError = 'No therapist assigned. Please contact support.';
       notifyListeners();
@@ -231,6 +237,11 @@ class AppointmentsProvider extends ChangeNotifier {
       if (result is ActionResultSuccess) {
         _bookingError = null;
         return true;
+      } else if (result is ActionResultFailure) {
+        _bookingError = (result.errorMessage?.isNotEmpty == true)
+            ? result.errorMessage
+            : 'Booking failed. Please try again.';
+        return false;
       } else {
         _bookingError = 'Booking failed. Please try again.';
         return false;
@@ -278,20 +289,26 @@ class AppointmentsProvider extends ChangeNotifier {
     try {
       final trimmed = slot.trim();
       if (trimmed.isEmpty) return null;
-      final parts = trimmed.split(' ');
+      final parts = trimmed.split(RegExp(r'\s+'));
+      if (parts.isEmpty || parts.length > 2) return null;
       final timeParts = parts[0].split(':');
-      if (timeParts.length < 2) return null;
+      if (timeParts.length != 2) return null;
       final parsedHour = int.tryParse(timeParts[0]);
       final parsedMinute = int.tryParse(timeParts[1]);
       if (parsedHour == null || parsedMinute == null) return null;
-      if (parsedHour < 0 || parsedHour > 23) return null;
       if (parsedMinute < 0 || parsedMinute > 59) return null;
+      final period = parts.length == 2 ? parts[1].toUpperCase() : null;
+      final hasPeriod = period != null;
+      if (hasPeriod && period != 'AM' && period != 'PM') return null;
       int hour = parsedHour;
       final minute = parsedMinute;
-      final isPM = parts.length > 1 && parts[1].toUpperCase() == 'PM';
-      final isAM = parts.length > 1 && parts[1].toUpperCase() == 'AM';
-      if (isPM && hour != 12) hour += 12;
-      if (isAM && hour == 12) hour = 0;
+      if (hasPeriod) {
+        if (hour < 1 || hour > 12) return null;
+        if (period == 'PM' && hour != 12) hour += 12;
+        if (period == 'AM' && hour == 12) hour = 0;
+      } else {
+        if (hour < 0 || hour > 23) return null;
+      }
       return DateTime(date.year, date.month, date.day, hour, minute);
     } catch (_) {
       return null;


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #219 


## 📝 Description

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->
Three separate bugs in the appointment booking flow caused every booking to be written to Supabase with a midnight timestamp, an empty therapist_id, and the wrong name. The selected time slot was captured in the model but toEntity() always called DateTime.parse(date) on a date-only string. therapistId was hardcoded to '' . 
name was wired to serviceType instead of appointmentName.

Additionally there were no pre-submission guards - the booking call could fire with a null date, empty slot, or empty therapist ID and either crash or insert garbage. The slot parser had no error handling, so a malformed slot would throw uncaught. The UI had no way to surface what went wrong since catch(e) silently returned false.

## 🔧 Changes Made

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- Added `_therapistId` field populated after the availability fetch, passed correctly into the model instead of hardcoded empty string
- Added `_bookingError` field and `bookingError` getter so the UI can display specific error messages instead of silently failing
- Added `isSubmitting` getter so the UI can disable the booking button during an in-flight request
- Added pre-submission validation guards for null date, empty slot, and empty therapist ID with descriptive error messages
- Added `_parseSlotToDateTime()` helper that safely parses slot strings like "10:00 AM" into a full DateTime, returns null on any malformed input instead of throwing
- `createAppointment()` now checks the parsed DateTime for null and sets a user facing error instead of crashing
- Fixed `name: serviceType` to `name: appointmentName` in `toConsultationRequestEntity()` so the correct appointment name is stored
- Added `.toLocal()` in `toEntity()` so the timestamp is stored in local time
- `clearSelections()` now resets `_therapistId`, `_isSubmitting`, and `_bookingError` alongside existing fields

## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->
Not applicable. The fix is in data written to Supabase, not visible in the UI.


## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: NONE


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed appointment name used during booking.
  * Corrected appointment date/time handling to use local timezone.
  * Added clearer error reporting when required booking details are missing or invalid.

* **Improvements**
  * Prevented concurrent appointment submissions.
  * Improved booking state tracking and feedback (including therapist association when viewing slots).
  * Better handling and parsing of selected time slots; clearing selections now resets booking state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->