### PR TITLE
fix: add submission guard and loading state to therapy save, deduplicate regression reports

### DIFF
--- a/patient/lib/repository/supabase_patient_repository.dart
+++ b/patient/lib/repository/supabase_patient_repository.dart
@@ -238,13 +238,16 @@ class SupabasePatientRepository implements PatientRepository {
       .gte('performed_on', startDate.toIso8601String())
       .lte('performed_on', endDate.toIso8601String());
 
+      final Set<String> seenRegressions = {};
       List<String> regressions = [];
       for(var i = 0; i < regresstionResponse.length; i++) {
         final regression = regresstionResponse[i]['regressions'];
         for(var j = 0; j < regression.length; j++) {
           final regressionItem = regression[j] is String ? jsonDecode(regression[j]) : regression[j];
-
-          regressions.add(regressionItem['name']);
+          final String regressionName = regressionItem['name'];
+          if (seenRegressions.add(regressionName)) {
+            regressions.add(regressionName);
+          }
         }
       }
       

--- a/therapist/lib/presentation/therapy_goals/therapy_goals_screen.dart
+++ b/therapist/lib/presentation/therapy_goals/therapy_goals_screen.dart
@@ -115,6 +115,7 @@ class _TherapyGoalsScreenState extends State<TherapyGoalsScreen> {
         padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 25),
         child: SaveTherapyButton(
           text: 'Save Therapy Details',
+          isLoading: therapyProvider.saveTherapyStatus.isLoading,
           onPressed: _onSaveTherapyDetails,
         ),
       ),

--- a/therapist/lib/presentation/therapy_goals/widgets/save_therapy_button.dart
+++ b/therapist/lib/presentation/therapy_goals/widgets/save_therapy_button.dart
@@ -6,31 +6,44 @@ class SaveTherapyButton extends StatelessWidget {
     super.key,
     required this.text,
     required this.onPressed,
+    this.isLoading = false,
   });
 
   final String text;
-  final VoidCallback onPressed;
-
+  final VoidCallback? onPressed;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: onPressed,
-      child: Container(
-        width: double.infinity,
-        height: 50,
-        decoration: BoxDecoration(
-          color: AppTheme.primaryColor,
-          borderRadius: BorderRadius.circular(10),
-        ),
-        child: Center(
-          child: Text(
-            text,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 16,
-              fontWeight: FontWeight.w700,
-            ),
+      onTap: isLoading ? null : onPressed,
+      child: Opacity(
+        opacity: isLoading ? 0.6 : 1.0,
+        child: Container(
+          width: double.infinity,
+          height: 50,
+          decoration: BoxDecoration(
+            color: AppTheme.primaryColor,
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Center(
+            child: isLoading
+                ? const SizedBox(
+                    height: 24,
+                    width: 24,
+                    child: CircularProgressIndicator(
+                      color: Colors.white,
+                      strokeWidth: 2.5,
+                    ),
+                  )
+                : Text(
+                    text,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
           ),
         ),
       ),

--- a/therapist/lib/provider/therapy_provider.dart
+++ b/therapist/lib/provider/therapy_provider.dart
@@ -219,27 +219,36 @@ class TherapyProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void saveTherapyDetails() async {
+  Future<void> saveTherapyDetails() async {
+    if (_saveTherapyStatus.isLoading) return;
+
     _saveTherapyStatus = SaveTherapyStatus.loading;
-    final therapyGoalModel = TherapyGoalModel(
-      performedOn: _selectedDateTime ?? DateTime.now(),
-      therapyTypeId: _getTherapyIdFromSelectedTherapy(),
-      goals: _selectedTherapyGoals,
-      observations: _selectedTherapyObservations,
-      regressions: _selectedTherapyRegressions,
-      activities: _selectedTherapyActivities,
-      patientId: _patientId,
-    );
+    notifyListeners();
 
-    final ActionResult result = await _therapyRepository.saveTherapyGoals(therapyGoalModel.toEntity());
+    try {
+      final therapyGoalModel = TherapyGoalModel(
+        performedOn: _selectedDateTime ?? DateTime.now(),
+        therapyTypeId: _getTherapyIdFromSelectedTherapy(),
+        goals: _selectedTherapyGoals,
+        observations: _selectedTherapyObservations,
+        regressions: _selectedTherapyRegressions,
+        activities: _selectedTherapyActivities,
+        patientId: _patientId,
+      );
 
-    if(result is ActionResultSuccess) {
-      _saveTherapyStatus = SaveTherapyStatus.success;
-      _saveTherapyErrorMessage = '';
-      notifyListeners();
-    } else {
+      final ActionResult result = await _therapyRepository.saveTherapyGoals(therapyGoalModel.toEntity());
+
+      if (result is ActionResultSuccess) {
+        _saveTherapyStatus = SaveTherapyStatus.success;
+        _saveTherapyErrorMessage = '';
+      } else {
+        _saveTherapyStatus = SaveTherapyStatus.failure;
+        _saveTherapyErrorMessage = result.errorMessage.toString();
+      }
+    } catch (e) {
       _saveTherapyStatus = SaveTherapyStatus.failure;
-      _saveTherapyErrorMessage = result.errorMessage.toString();
+      _saveTherapyErrorMessage = e.toString();
+    } finally {
       notifyListeners();
     }
   }


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #221 


## 📝 Description

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->
`saveTherapyDetails()` set `_saveTherapyStatus = SaveTherapyStatus.loading` but never called `notifyListeners()`, so the save button stayed fully active during the network call with no visual feedback. On any slow connection a therapist could tap the button multiple times, inserting duplicate rows into the `therapy_goal` table. The patient Reports screen then appended regressions from every row with no deduplication, causing the same regression to appear multiple times and making the patient's clinical profile look worse than reality.


## 🔧 Changes Made

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- Added a re-entry guard to `saveTherapyDetails()` that returns early if status is already loading, preventing concurrent duplicate submissions
- Called `notifyListeners()` immediately after setting loading state so the UI reacts
- Changed return type from `void` to `Future<void>`
- Wrapped the method body in try-catch-finally so `notifyListeners()` fires on all paths including exceptions
- Added `isLoading` parameter to `SaveTherapyButton` - sets `onTap` to null and shows a `CircularProgressIndicator` when loading
- Added `Opacity` wrapper to visually indicate disabled state during submission
- Passed `therapyProvider.saveTherapyStatus.isLoading` to the button in `therapy_goals_screen.dart`
- Added `Set<String> seenRegressions` deduplication in `getReports()` so duplicate `therapy_goal` rows in the database do not inflate the patient's regression report


## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->
Not applicable. The core fix is in data integrity and provider state. The only visual change is the save button now shows a spinner and dims during submission.

## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: NONE


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate regression names appearing in patient reports, ensuring each regression is listed only once for improved clarity.
  * Improved error handling and state management when saving therapy details to ensure application consistency and reliability.

* **New Features**
  * Added visual loading indicator to the therapy goals save button, providing clear feedback during save operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->